### PR TITLE
gps_module_working_goal: Basic features for communication with the gps board are functioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Therefore the software has to communicate with the ublox gps module through a se
 The high time accuracy is needed because it is planned to use multiple stations for measuring myons.
 The software must be easy to use and run in background while synchronizing accumulated data with a server via tcp.
 It also has to be remotely controllable via tcp.
+
+
+ATTENTION:  when trying to create Makefile with qmake (qt version 5.7.1 on raspbian) there will probably be an error:
+            "Project ERROR: unknown module(s) in QT: serialport"
+            there is missing library "libqt5serialport5-dev". To install just get it from repository with apt-get install

--- a/myon_detector/client.cpp
+++ b/myon_detector/client.cpp
@@ -69,6 +69,7 @@ void Client::connectToGps(){
     connect(qtGps,&QtSerialUblox::toConsole, this, &Client::gpsToConsole);
     connect(gpsThread, &QThread::started, qtGps, &QtSerialUblox::makeConnection);
     // connect all command signals for ublox module here
+    connect(this, &Client::UBXSetCfgPrt, qtGps, &QtSerialUblox::UBXSetCfgPrt);
     connect(this, &Client::UBXSetCfgMsg, qtGps, &QtSerialUblox::UBXSetCfgMsg);
     connect(this, &Client::UBXSetCfgRate, qtGps, &QtSerialUblox::UBXSetCfgRate);
     connect(this, &Client::sendPoll, qtGps, &QtSerialUblox::sendPoll);
@@ -101,31 +102,10 @@ void Client::connectToServer(){
 
 void Client::configGps() {
     // set up ubx as only outPortProtocol
-    emit UBXSetCfgPrt(1,1); // enables on UART port (1) only the UBX protocol
-
+    //emit UBXSetCfgPrt(1,1); // enables on UART port (1) only the UBX protocol
+    emit UBXSetCfgPrt(1,PROTO_UBX);
     // deactivate all NMEA messages: (port 6 means ALL ports)
-
-    // first remember (in a QHash) which messages are waiting for AckAck
-    // must think about what is sent as classID and msgID from AckAck (is it maybe always CFG_MSG ??)
-    /*messagesWaitingForAck->insert(MSG_NMEA_DTM,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GBQ,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GBS,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GGA,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GLL,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GLQ,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GNQ,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GNS,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GPQ,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GRS,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GSA,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GST,true);
-    messagesWaitingForAck->insert(MSG_NMEA_GSV,true);
-    messagesWaitingForAck->insert(MSG_NMEA_RMC,true);
-    messagesWaitingForAck->insert(MSG_NMEA_TXT,true);
-    messagesWaitingForAck->insert(MSG_NMEA_VLW,true);
-    messagesWaitingForAck->insert(MSG_NMEA_VTG,true);
-    messagesWaitingForAck->insert(MSG_NMEA_ZDA,true);
-    messagesWaitingForAck->insert(MSG_NMEA_POSITION,true);*/
+    // for acknowledge we have to think about a better solution
     emit UBXSetCfgMsg(MSG_NMEA_DTM,6,0);
     emit UBXSetCfgMsg(MSG_NMEA_GBQ,6,0);
     emit UBXSetCfgMsg(MSG_NMEA_GBS,6,0);
@@ -149,8 +129,6 @@ void Client::configGps() {
     // set protocol configuration for ports
     delay(2000);
     const int measrate = 10;
-    // set active UBX messages
-    // also remember (in QHash) which messages are waiting for AckAck (have to overthink it)
     emit UBXSetCfgRate(1000 / measrate, 1);
     emit UBXSetCfgMsg(MSG_TIM_TM2, 1, 1);	// TIM-TM2
 	emit UBXSetCfgMsg(MSG_TIM_TP, 1, 51);	// TIM-TP

--- a/myon_detector/client.cpp
+++ b/myon_detector/client.cpp
@@ -107,9 +107,6 @@ Client::Client(std::string new_gpsdevname, int new_verbose, bool new_allSats,
     if (configGnss) {
         configGps();
     }
-    delay(1000);
-    //emit sendMsg("testMessage");
-    emit sendFile("lang.txt");
 }
 
 void Client::connectToServer(){

--- a/myon_detector/client.cpp
+++ b/myon_detector/client.cpp
@@ -53,8 +53,10 @@ Client::Client(QString new_gpsdevname, int new_verbose, bool new_allSats,
     if (verbose > 2){
         cout << "client initialization complete, tcp und gps thread started" << endl;
     }
-    emit UBXSetCfgRate(100, 1);
-    emit UBXSetCfgMsg(MSG_TIM_TM2, 1, 1);	// TIM-TM2 activates the timemark function (external interrupt)
+    if(configGnss){
+        emit UBXSetCfgRate(100, 1);
+        emit UBXSetCfgMsg(MSG_TIM_TM2, 1, 1);	// TIM-TM2 activates the timemark function (external interrupt)
+    }
 }
 
 void Client::connectToGps(){

--- a/myon_detector/client.cpp
+++ b/myon_detector/client.cpp
@@ -53,8 +53,6 @@ Client::Client(QString new_gpsdevname, int new_verbose, bool new_allSats,
     if (verbose > 2){
         cout << "client initialization complete, tcp und gps thread started" << endl;
     }
-    emit UBXSetCfgRate(100, 1);
-    emit UBXSetCfgMsg(MSG_TIM_TM2, 1, 1);	// TIM-TM2 activates the timemark function (external interrupt)
 }
 
 void Client::connectToGps(){
@@ -72,13 +70,6 @@ void Client::connectToGps(){
     qtGps->moveToThread(gpsThread);
     connect(qtGps,&QtSerialUblox::toConsole, this, &Client::gpsToConsole);
     connect(gpsThread, &QThread::started, qtGps, &QtSerialUblox::makeConnection);
-    // connect all command signals for ublox module here
-    connect(this, &Client::UBXSetCfgMsg, qtGps, &QtSerialUblox::UBXSetCfgMsg);
-    connect(this, &Client::UBXSetCfgRate, qtGps, &QtSerialUblox::UBXSetCfgRate);
-    // connect cfgError signal to output, could also create special errorFunction
-    connect(qtGps, &QtSerialUblox::UBXCfgError, this, &Client::toConsole);
-
-    // after thread start there will be a signal emitted which starts the qtGps makeConnection function
     gpsThread->start();
 }
 

--- a/myon_detector/client.cpp
+++ b/myon_detector/client.cpp
@@ -10,52 +10,41 @@ Client::Client(QString new_gpsdevname, int new_verbose, bool new_allSats,
     bool new_configGnss, int new_timingCmd, long int new_N,QString serverAddress, quint16 serverPort, QObject *parent)
 	: QObject(parent)
 {
-    //connect(this, &Client::posixTerminate, this, &Client::deleteLater);
+    // set all variables
+
+    // general
+    verbose = new_verbose;
     if (verbose > 2){
         cout << "client running in thread " << this->thread() << endl;
     }
-	// All the stuff to make the tcp connection work
 
-	// find out IP to connect
-	/*QList<QHostAddress> ipAddressesList = QNetworkInterface::allAddresses();
-	// use the first non-localhost IPv4 address
-	for (int i = 0; i < ipAddressesList.size(); ++i) {
-		if (ipAddressesList.at(i) != QHostAddress::LocalHost &&
-			ipAddressesList.at(i).toIPv4Address()) {
-			ipAddress = ipAddressesList.at(i).toString();
-			break;
-		}
-	}*/
-	// use localhost for test purposes
-	// if we did not find one, use IPv4 localhost
+    // for gps module
+    gpsdevname = new_gpsdevname;
+    allSats = new_allSats;
+    listSats = new_listSats;
+    dumpRaw = new_dumpRaw;
+    baudrate = new_baudrate;
+    poll = new_poll;
+    configGnss = new_configGnss;
+    timingCmd = new_timingCmd;
+    N = new_N;
 
-    ipAddress = serverAddress;
-    if (ipAddress.isEmpty()||ipAddress == "local"||ipAddress == "localhost") {
-		ipAddress = QHostAddress(QHostAddress::LocalHost).toString();
-    }
+    // for tcp connection
     port = serverPort;
     if (port == 0){
         port = 51508;
     }
-    connectToServer();
-	// All the stuff to make the gps module work
-	gpsdevname = new_gpsdevname;
-	verbose = new_verbose;
-	allSats = new_allSats;
-	listSats = new_listSats;
-	dumpRaw = new_dumpRaw;
-	baudrate = new_baudrate;
-	poll = new_poll;
-	configGnss = new_configGnss;
-	timingCmd = new_timingCmd;
-	N = new_N;
-    connectToGps();
-    if (verbose > 2){
-        cout << "client initialization complete, tcp und gps thread started" << endl;
+    ipAddress = serverAddress;
+    if (ipAddress.isEmpty()||ipAddress == "local"||ipAddress == "localhost") {
+        ipAddress = QHostAddress(QHostAddress::LocalHost).toString();
     }
+
+    // start tcp connection and gps module connection
+    connectToServer();
+    connectToGps();
     if(configGnss){
-        emit UBXSetCfgRate(100, 1);
-        emit UBXSetCfgMsg(MSG_TIM_TM2, 1, 1);	// TIM-TM2 activates the timemark function (external interrupt)
+        emit UBXSetCfgMsg(MSG_NAV_STATUS, 1, 1);	// TIM-TP
+        emit UBXSetCfgMsg(MSG_TIM_TP, 1, 1);	// TIM-TP
     }
 }
 
@@ -287,7 +276,7 @@ void Client::toConsole(QString data) {
 }
 
 void Client::gpsToConsole(QString data){
-    cout << data;
+    cout << data << flush;
 }
 
 void Client::stoppedConnection(QString hostName, quint16 port, quint32 connectionTimeout, quint32 connectionDuration){

--- a/myon_detector/client.h
+++ b/myon_detector/client.h
@@ -40,7 +40,6 @@ signals:
     //void posixTerminate();
     void sendFile(QString fileName);
     void sendMsg(QString msg);
-	void UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate);
 	void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate);
 	void UBXSetCfgRate(uint8_t measRate, uint8_t navRate);
 

--- a/myon_detector/client.h
+++ b/myon_detector/client.h
@@ -14,7 +14,7 @@ class Client : public QObject
 public:
     Client(QString new_gpsdevname, int new_verbose, bool new_allSats,
         bool new_listSats, bool new_dumpRaw, int new_baudrate, bool new_poll,
-        bool new_configGnss, int new_timingCmd, long int new_N, QString serverAddress, quint16 serverPort, QObject *parent = 0);
+        bool new_configGnss, int new_timingCmd, long int new_N, QString serverAddress, quint16 serverPort, bool new_showout, QObject *parent = 0);
 	void configGps();
 	void loop();
 
@@ -54,7 +54,7 @@ private:
     QString gpsdevname;
 	int verbose, timingCmd, baudrate;
 	long int N;
-	bool allSats, listSats, dumpRaw, poll, configGnss;
+    bool allSats, listSats, dumpRaw, poll, configGnss, showout;
 };
 
 #endif // CLIENT_H

--- a/myon_detector/client.h
+++ b/myon_detector/client.h
@@ -40,6 +40,7 @@ signals:
     //void posixTerminate();
     void sendFile(QString fileName);
     void sendMsg(QString msg);
+    void sendPoll(uint16_t msgID);
 	void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate);
 	void UBXSetCfgRate(uint8_t measRate, uint8_t navRate);
 

--- a/myon_detector/client.h
+++ b/myon_detector/client.h
@@ -5,13 +5,14 @@
 #include "tcpconnection.h"
 #include "custom_io_operators.h"
 #include "ublox.h"
+#include "qtserialublox.h"
 
 class Client : public QObject
 {
 	Q_OBJECT
 
 public:
-    Client(std::string new_gpsdevname, int new_verbose, bool new_allSats,
+    Client(QString new_gpsdevname, int new_verbose, bool new_allSats,
         bool new_listSats, bool new_dumpRaw, int new_baudrate, bool new_poll,
         bool new_configGnss, int new_timingCmd, long int new_N, QString serverAddress, quint16 serverPort, QObject *parent = 0);
 	void configGps();
@@ -19,10 +20,12 @@ public:
 
 public slots:
     //void onPosixTerminateReceived();
+    void connectToGps();
     void connectToServer();
     void displaySocketError(int socketError, QString message);
 	void displayError(QString message);
     void toConsole(QString data);
+    void gpsToConsole(QString data);
     void stoppedConnection(QString hostName, quint16 port, quint32 connectionTimeout, quint32 connectionDuration);
     void gpsPropertyUpdatedInt32(int32_t data, std::chrono::duration<double> updateAge,
                             char propertyName);
@@ -42,13 +45,14 @@ signals:
 	void UBXSetCfgRate(uint8_t measRate, uint8_t navRate);
 
 private:
-    TcpConnection * tcpConnection;
-	Ublox *gps;
+    TcpConnection * tcpConnection = nullptr;
+    Ublox *gps = nullptr;
+    QtSerialUblox *qtGps = nullptr;
 	QString ipAddress;
 	quint16 port;
 	void printTimestamp();
 	void delay(int millisecondsWait);
-	std::string gpsdevname;
+    QString gpsdevname;
 	int verbose, timingCmd, baudrate;
 	long int N;
 	bool allSats, listSats, dumpRaw, poll, configGnss;

--- a/myon_detector/client.h
+++ b/myon_detector/client.h
@@ -4,7 +4,7 @@
 #include <QObject>
 #include "tcpconnection.h"
 #include "custom_io_operators.h"
-#include "ublox.h"
+//#include "ublox.h"
 #include "qtserialublox.h"
 
 class Client : public QObject
@@ -46,7 +46,7 @@ signals:
 
 private:
     TcpConnection * tcpConnection = nullptr;
-    Ublox *gps = nullptr;
+    //Ublox *gps = nullptr;
     QtSerialUblox *qtGps = nullptr;
 	QString ipAddress;
 	quint16 port;

--- a/myon_detector/client.h
+++ b/myon_detector/client.h
@@ -40,6 +40,7 @@ signals:
     //void posixTerminate();
     void sendFile(QString fileName);
     void sendMsg(QString msg);
+	void UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate);
 	void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate);
 	void UBXSetCfgRate(uint8_t measRate, uint8_t navRate);
 

--- a/myon_detector/client.h
+++ b/myon_detector/client.h
@@ -40,12 +40,14 @@ signals:
     //void posixTerminate();
     void sendFile(QString fileName);
     void sendMsg(QString msg);
-    void sendPoll(uint16_t msgID);
+    void sendPoll(uint16_t msgID, uint8_t port);
 	void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate);
 	void UBXSetCfgRate(uint8_t measRate, uint8_t navRate);
+    void UBXSetCfgPrt(uint8_t gpsPort, uint8_t outProtocolMask);
 
 private:
     TcpConnection * tcpConnection = nullptr;
+    QHash <uint16_t, bool> *messagesWaitingForAck;
     //Ublox *gps = nullptr;
     QtSerialUblox *qtGps = nullptr;
 	QString ipAddress;

--- a/myon_detector/main.cpp
+++ b/myon_detector/main.cpp
@@ -200,7 +200,7 @@ int main(int argc, char *argv[])
             cout << "wrong input port (maybe not an integer)" << endl;
         }
     }
-    QString ipAddress;
+    QString ipAddress = "";
     if (parser.isSet(ipOption)){
         ipAddress = parser.value(ipOption);
         if (!QHostAddress(ipAddress).toIPv4Address()){
@@ -210,7 +210,7 @@ int main(int argc, char *argv[])
             }
         }
     }
-	Client client(gpsdevname.toStdString(), verbose, allSats, listSats, dumpRaw,
+    Client client(gpsdevname, verbose, allSats, listSats, dumpRaw,
         baudrate, poll, showGnssConfig, timingCmd, N, ipAddress, port);
 
     /* handling posix signals does not really work atm

--- a/myon_detector/main.cpp
+++ b/myon_detector/main.cpp
@@ -6,7 +6,6 @@
 #include "custom_io_operators.h"
 #include "client.h"
 //#include "unix_sig_handler_daemon.h" //for handling unix signals
-
 using namespace std;
 
 /* for handling unix signals, does not really work
@@ -51,6 +50,7 @@ int main(int argc, char *argv[])
     qRegisterMetaType<uint16_t>("uint16_t");
     qRegisterMetaType<uint32_t>("uint32_t");
     qRegisterMetaType<int32_t>("int32_t");
+    qRegisterMetaType<std::string>("std::string");
 
 	// command line input management
 	QCommandLineParser parser;

--- a/myon_detector/main.cpp
+++ b/myon_detector/main.cpp
@@ -129,6 +129,10 @@ int main(int argc, char *argv[])
 		QCoreApplication::translate("main", "show GNSS configs"));
 	parser.addOption(showGnssConfigOption);
 
+    // show outgoing ubx messages as hex
+    QCommandLineOption showoutOption(QStringList() << "showoutput" << "showout",
+        QCoreApplication::translate("main", "show outgoing ubx messages as hex"));
+    parser.addOption(showoutOption);
 
 	// process the actual command line arguments given by the user
 	parser.process(a);
@@ -154,9 +158,9 @@ int main(int argc, char *argv[])
 			cout << "wrong input verbosity level" << endl;
 		}
 	}
-    if (verbose > 2){
+    if (verbose > 4){
         cout << "int main running in thread "
-             << QCoreApplication::instance()->thread() << endl;
+             << QString("0x%1").arg((int)QCoreApplication::instance()->thread()) << endl;
     }
 	long int N = -1;
 	if (parser.isSet(numberReadCyclesOption)) {
@@ -210,8 +214,11 @@ int main(int argc, char *argv[])
             }
         }
     }
+    bool showout = false;
+    showout = parser.isSet(showoutOption);
+
     Client client(gpsdevname, verbose, allSats, listSats, dumpRaw,
-        baudrate, poll, showGnssConfig, timingCmd, N, ipAddress, port);
+        baudrate, poll, showGnssConfig, timingCmd, N, ipAddress, port, showout);
 
     /* handling posix signals does not really work atm
     QObject::connect(d, SIGNAL(myIntSignal()),&client,

--- a/myon_detector/myon_detector.pro
+++ b/myon_detector/myon_detector.pro
@@ -22,7 +22,6 @@ SOURCES += main.cpp \
     custom_io_operators.cpp \
     client.cpp \
     gnsssatellite.cpp \
-    serial.cpp \
     tcpconnection.cpp \
     qtserialublox.cpp \
     qtserialublox_processmessages.cpp

--- a/myon_detector/myon_detector.pro
+++ b/myon_detector/myon_detector.pro
@@ -18,23 +18,24 @@ DEFINES += QT_DEPRECATED_WARNINGS
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 SOURCES += main.cpp \
-    ublox.cpp \
+#    ublox.cpp \
     custom_io_operators.cpp \
     client.cpp \
     gnsssatellite.cpp \
     serial.cpp \
     tcpconnection.cpp \
-    qtserialublox.cpp
+    qtserialublox.cpp \
+    qtserialublox_processmessages.cpp
 
 HEADERS += \
-    ublox.h \
+#    ublox.h \
     custom_io_operators.h \
     client.h \
     gnsssatellite.h \
     unixtime_from_gps.h \
     structs_and_defines.h \
     time_from_rtc.h \
-    serial.h \
+#    serial.h \
     tcpconnection.h \
     qtserialublox.h
 

--- a/myon_detector/myon_detector.pro
+++ b/myon_detector/myon_detector.pro
@@ -1,6 +1,7 @@
 QT -= gui
 QT += core
 QT += network
+QT += serialport
 
 CONFIG += c++11 console
 CONFIG -= app_bundle
@@ -22,7 +23,8 @@ SOURCES += main.cpp \
     client.cpp \
     gnsssatellite.cpp \
     serial.cpp \
-    tcpconnection.cpp
+    tcpconnection.cpp \
+    qtserialublox.cpp
 
 HEADERS += \
     ublox.h \
@@ -33,6 +35,7 @@ HEADERS += \
     structs_and_defines.h \
     time_from_rtc.h \
     serial.h \
-    tcpconnection.h
+    tcpconnection.h \
+    qtserialublox.h
 
 #QMAKE_CXXFLAGS += -std=c++11

--- a/myon_detector/qtserialublox.cpp
+++ b/myon_detector/qtserialublox.cpp
@@ -91,7 +91,7 @@ void QtSerialUblox::calcChkSum(const std::string& buf, unsigned char* chkA, unsi
     }
 }
 
-void QtSerialUblox::UBXSetCfgRate(uint8_t measRate, uint8_t navRate)
+void QtSerialUblox::UBXSetCfgRate(uint8_t measRate, uint8_t navRate, int verbose)
 {
     if (verbose>2){
         emit toConsole(QString("Ublox UBXsetCfgRate running in thread "  + QString( "0x%1" )
@@ -120,7 +120,7 @@ void QtSerialUblox::UBXSetCfgRate(uint8_t measRate, uint8_t navRate)
     */
 }
 
-void QtSerialUblox::UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate)
+void QtSerialUblox::UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate, int verbose)
 {
     if (verbose>2){
         emit toConsole(QString("Ublox UBXsetCfgMsg running in thread "  + QString( "0x%1" )
@@ -145,7 +145,7 @@ void QtSerialUblox::UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate)
     */
 }
 
-void QtSerialUblox::UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate)
+void QtSerialUblox::UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate, int verbose)
 {
     uint16_t msgID = (messageID + (uint16_t)classID) << 8;
     UBXSetCfgMsg(msgID, port, rate, verbose);

--- a/myon_detector/qtserialublox.cpp
+++ b/myon_detector/qtserialublox.cpp
@@ -1,0 +1,11 @@
+#include <QSerialPort>
+#include "qtserialublox.h"
+
+QtSerialUblox::QtSerialUblox(const QString &serialPortName, int baudRate,
+                             QObject *parent, bool newDumpRaw, int newVerbose, QObject *parent) : QObject(parent)
+{
+    _portName = serialPortName;
+    _baudRate = baudRate;
+    verbose = newVerbose;
+    dumpRaw = newDumpRaw;
+}

--- a/myon_detector/qtserialublox.cpp
+++ b/myon_detector/qtserialublox.cpp
@@ -91,7 +91,7 @@ void QtSerialUblox::calcChkSum(const std::string& buf, unsigned char* chkA, unsi
     }
 }
 
-void QtSerialUblox::UBXSetCfgRate(uint8_t measRate, uint8_t navRate, int verbose)
+void QtSerialUblox::UBXSetCfgRate(uint8_t measRate, uint8_t navRate)
 {
     if (verbose>2){
         emit toConsole(QString("Ublox UBXsetCfgRate running in thread "  + QString( "0x%1" )
@@ -120,7 +120,7 @@ void QtSerialUblox::UBXSetCfgRate(uint8_t measRate, uint8_t navRate, int verbose
     */
 }
 
-void QtSerialUblox::UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate, int verbose)
+void QtSerialUblox::UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate)
 {
     if (verbose>2){
         emit toConsole(QString("Ublox UBXsetCfgMsg running in thread "  + QString( "0x%1" )
@@ -145,7 +145,7 @@ void QtSerialUblox::UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate, int
     */
 }
 
-void QtSerialUblox::UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate, int verbose)
+void QtSerialUblox::UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate)
 {
     uint16_t msgID = (messageID + (uint16_t)classID) << 8;
     UBXSetCfgMsg(msgID, port, rate, verbose);

--- a/myon_detector/qtserialublox.cpp
+++ b/myon_detector/qtserialublox.cpp
@@ -17,7 +17,7 @@ void QtSerialUblox::makeConnection(){
     // this function gets called with a signal from client-thread
     // (QtSerialUblox runs in a separate thread only communicating with main thread through messages)
     if (verbose > 4){
-        emit toConsoleNewLine(QString("gps running in thread " + QString( "0x%1" ).arg( (int)this->thread())));
+        emit toConsole(QString("gps running in thread " + QString( "0x%1\n" ).arg( (int)this->thread())));
     }
     if (serialPort){
         delete(serialPort);
@@ -25,7 +25,7 @@ void QtSerialUblox::makeConnection(){
     serialPort = new QSerialPort(_portName);
     serialPort->setBaudRate(_baudRate);
     if (!serialPort->open(QIODevice::ReadWrite)) {
-        emit toConsole(QObject::tr("Failed to open port %1, error: %2")
+        emit toConsole(QObject::tr("Failed to open port %1, error: %2\n")
                           .arg(_portName)
                           .arg(serialPort->errorString()));
         return;
@@ -87,9 +87,6 @@ bool QtSerialUblox::scanUnknownMessage(string &buffer, UbxMessage &message)
     message.msgID = (uint16_t)mess[2] << 8;
     message.msgID += (uint16_t)mess[3];
     if (mess.size() < 8) return false;
-    //        cout<<"received UBX string: ";
-    //        for (int i=0; i<mess.size(); i++) cout<<hex<<(int)mess[i]<<" ";
-    //        cout<<endl;
     int len = (int)(mess[4]);
     len += ((int)(mess[5])) << 8;
     if (((long int)mess.size() - 8) < len) {
@@ -97,22 +94,18 @@ bool QtSerialUblox::scanUnknownMessage(string &buffer, UbxMessage &message)
         if (found != string::npos) {
             std::stringstream tempStream;
             tempStream << "received faulty UBX string:\n " << dec;
-            for (std::string::size_type i = 0; i < found; i++) tempStream << hex << (int)buffer[i] << " ";
+            for (std::string::size_type i = 0; i < found; i++) tempStream
+                    << setw(2) << hex << "0x" <<(int)buffer[i] << " ";
             emit toConsole(QString::fromStdString(tempStream.str()));
             buffer.erase(0, found);
         }
         return false;
     }
-    //    cout<<"len="<<dec<<len<<endl;
-    //    cout<<"mess.size()="<<dec<<mess.size()<<endl;
-    //	cout<<"da2"<<endl;
     buffer.erase(0, len + 8);
 
     unsigned char chkA;
     unsigned char chkB;
     calcChkSum(mess.substr(0, len + 6), &chkA, &chkB);
-    //     cout<<"chkA/B="<<hex<<(int)chkA<<" "<<(int)chkB<<endl;
-    //     cout<<"mess[len+6/7]="<<hex<<(int)mess[len+6]<<" "<<(int)mess[len+7]<<endl;
     if (mess[len + 6] == chkA && mess[len + 7] == chkB)
     {
         message.data = mess.substr(6, len);
@@ -143,11 +136,12 @@ bool QtSerialUblox::sendUBX(uint16_t msgID, unsigned char* payload, int nBytes)
     //QByteArray block;
     //block.append(QString::fromStdString(s));
     if (serialPort){
-        if (serialPort->write(s.c_str())){
+        QByteArray block(s.c_str(),s.size());
+        if (serialPort->write(block)){
             if(serialPort->waitForBytesWritten(timeout)){
                 if (showout){
                     std::stringstream tempStream;
-                    tempStream << "\nmessage sent: ";
+                    tempStream << "message sent: ";
                     for (std::string::size_type i = 0; i < s.length(); i++){
                         tempStream << "0x"<<std::setfill('0') << std::setw(2) << std::hex << (int)s[i] << " ";
                     }
@@ -188,10 +182,14 @@ void QtSerialUblox::calcChkSum(const std::string& buf, unsigned char* chkA, unsi
 void QtSerialUblox::UBXSetCfgRate(uint8_t measRate, uint8_t navRate)
 {
     if (verbose>4){
-        emit toConsoleNewLine(QString("Ublox UBXsetCfgRate running in thread "  + QString( "0x%1" )
+        emit toConsole(QString("Ublox UBXsetCfgRate running in thread "  + QString( "0x%1\n" )
                                .arg( (int)this->thread())));
     }
-        unsigned char data[6];
+    unsigned char data[6];
+    // initialise all contents from data as 0 first!
+    for (int i = 0; i < 6; i++){
+        data[i]=0;
+    }
     if (measRate < 10 || navRate < 1 || navRate>127) {
         emit UBXCfgError("measRate <10 || navRate<1 || navRate>127 error");
     }
@@ -215,19 +213,30 @@ void QtSerialUblox::UBXSetCfgRate(uint8_t measRate, uint8_t navRate)
 }
 
 void QtSerialUblox::UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate)
-{
+{ // set message rate on port. (rate 1 means every intervall the messages is sent)
+    // if port = -1 set all ports
     if (verbose>4){
-        emit toConsoleNewLine(QString("Ublox UBXsetCfgMsg running in thread "  + QString( "0x%1" )
+        emit toConsole(QString("Ublox UBXsetCfgMsg running in thread "  + QString( "0x%1\n" )
                                .arg( (int)this->thread())));
     }
     unsigned char data[8];
-    if (port > 5) {
+    // initialise all contents from data as 0 first!
+    for (int i = 0; i < 8; i++){
+        data[i]=0;
+    }
+    if (port > 6) {
         emit UBXCfgError("port > 5 is not possible");
     }
     data[0] = (uint8_t)((msgID & 0xff00) >> 8);
     data[1] = msgID & 0xff;
     //   cout<<"data[0]="<<(int)data[0]<<" data[1]="<<(int)data[1]<<endl;
-    data[2 + port] = rate;
+    if (port!=6){
+        data[2 + port] = rate;
+    }else{
+        for (int i = 2; i < 6; i++){
+            data[i] = rate;
+        }
+    }
     sendUBX(MSG_CFG_MSG, data, 8);
     /* Ack check has to be done differently, asynchronously
     if (waitAck(MSG_CFG_MSG, 12000)) {
@@ -249,7 +258,7 @@ void QtSerialUblox::handleError(QSerialPort::SerialPortError serialPortError)
 {
     if (serialPortError == QSerialPort::ReadError) {
         emit toConsole(QObject::tr("An I/O error occurred while reading "
-                                        "the data from port %1, error: %2")
+                                        "the data from port %1, error: %2\n")
                             .arg(serialPort->portName())
                             .arg(serialPort->errorString()));
     }
@@ -257,51 +266,7 @@ void QtSerialUblox::handleError(QSerialPort::SerialPortError serialPortError)
 
 
 
-bool QtSerialUblox::pollUBX(uint16_t msgID, std::string& answer, int timeout)
-{
-    sendUBX(msgID, NULL, 0);
-    int iter = 0;
-    answer = "";
-    //std::string buffer = "";
-    while (iter < timeout && !answer.size())
-    {
-        /*
-                std::string buf="";
-                int n=ReadBuffer(buf);
-                if (n>0) {
-                    buffer+=buf;
-                    iter++;
-                    answer=scanMessage(buffer,classID,messageID);
-                }
-        */
-        // include something about sleep maybe 1 ms
-        //usleep(1);
-        iter++;
-        //mutex.lock();
-        for (std::list<UbxMessage>::iterator it = fMessageBuffer.begin(); it != fMessageBuffer.end(); it++) {
-            if (it->msgID == msgID) {
-                answer = it->data;
-                fMessageBuffer.erase(it);
-                break;
-            }
-        }
-        //mutex.unlock();
-    }
-    if (iter >= timeout) return false;
-    if (verbose > 2) {
-        std::stringstream tempStream;
-        //std::string temp;
-        tempStream << "received UBX string: ";
-        for (std::string::size_type i = 0; i < answer.size(); i++) tempStream << hex << (int)answer[i] << " ";
-        //tempStream >> temp;
-        emit toConsole(QString::fromStdString(tempStream.str()));
-    }
-    if (answer.size()) return true;
-    return false;
+void QtSerialUblox::sendPoll(uint16_t msgID){
+    sendUBX(msgID,NULL,0);
 }
 
-bool QtSerialUblox::pollUBX(uint8_t classID, uint8_t messageID, std::string& answer, int timeout)
-{
-    uint16_t msgID = (messageID + (uint16_t)classID) << 8;
-    return pollUBX(msgID, answer, timeout);
-}

--- a/myon_detector/qtserialublox.cpp
+++ b/myon_detector/qtserialublox.cpp
@@ -37,6 +37,120 @@ void QtSerialUblox::onReadyRead(){
     emit toConsole(QString(temp));
 }
 
+bool QtSerialUblox::sendUBX(uint16_t msgID, unsigned char* payload, int nBytes)
+{
+    std::string s = "";
+    s += 0xb5; s += 0x62;
+    s += (unsigned char)((msgID & 0xff00) >> 8);
+    s += (unsigned char)(msgID & 0xff);
+    s += (unsigned char)(nBytes & 0xff);
+    s += (unsigned char)((nBytes & 0xff00) >> 8);
+    for (int i = 0; i < nBytes; i++) s += payload[i];
+    unsigned char chkA, chkB;
+    calcChkSum(s, &chkA, &chkB);
+    s += chkA;
+    s += chkB;
+    //   cout<<endl<<endl;
+    //   cout<<"write UBX string: ";
+    //   for (int i=0; i<s.size(); i++) cout<<hex<<(int)s[i]<<" ";
+    //   cout<<endl<<endl;
+    //if (s.size() == WriteBuffer(s)) return true;
+    QByteArray block;
+    block.append(QString::fromStdString(s));
+    if (serialPort){
+        if (serialPort->write(block)){
+            if(serialPort->waitForBytesWritten(timeout)){
+               return true;
+            }else{
+                emit toConsole("wait for bytes written timeout while trying to write to serialPort");
+            }
+        }else{
+            emit toConsole("error writing to serialPort");
+        }
+    }else{
+        emit toConsole("error: serialPort not instantiated");
+    }
+    return false;
+}
+
+bool QtSerialUblox::sendUBX(unsigned char classID, unsigned char messageID, unsigned char* payload, int nBytes)
+{
+    uint16_t msgID = (messageID + (uint16_t)classID) << 8;
+    return sendUBX(msgID, payload, nBytes);
+}
+
+void QtSerialUblox::calcChkSum(const std::string& buf, unsigned char* chkA, unsigned char* chkB)
+{
+    // calc Fletcher checksum, ignore the message header (b5 62)
+    *chkA = 0;
+    *chkB = 0;
+    for (std::string::size_type i = 2; i < buf.size(); i++)
+    {
+        *chkA += buf[i];
+        *chkB += *chkA;
+    }
+}
+
+void QtSerialUblox::UBXSetCfgRate(uint8_t measRate, uint8_t navRate, int verbose)
+{
+    if (verbose>2){
+        emit toConsole(QString("Ublox UBXsetCfgRate running in thread "  + QString( "0x%1" )
+                               .arg( (int)this->thread(), 16 )));
+    }
+        unsigned char data[6];
+    if (measRate < 10 || navRate < 1 || navRate>127) {
+        emit UBXCfgError("measRate <10 || navRate<1 || navRate>127 error");
+    }
+    data[0] = measRate & 0xff;
+    data[1] = (measRate & 0xff00) >> 8;
+    data[2] = navRate & 0xff;
+    data[3] = (navRate & 0xff00) >> 8;
+    data[4] = 0;
+    data[5] = 0;
+
+    sendUBX(MSG_CFG_RATE, data, sizeof(data));
+    /* Ack check has to be done differently, asynchronously
+    if (waitAck(MSG_CFG_RATE, 10000))
+    {
+        emit toConsole("Set CFG successful");
+    }
+    else {
+        emit UBXCfgError("Set CFG timeout");
+    }
+    */
+}
+
+void QtSerialUblox::UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate, int verbose)
+{
+    if (verbose>2){
+        emit toConsole(QString("Ublox UBXsetCfgMsg running in thread "  + QString( "0x%1" )
+                               .arg( (int)this->thread(), 16 )));
+    }
+    unsigned char data[8];
+    if (port > 5) {
+        emit UBXCfgError("port > 5 is not possible");
+    }
+    data[0] = (uint8_t)((msgID & 0xff00) >> 8);
+    data[1] = msgID & 0xff;
+    //   cout<<"data[0]="<<(int)data[0]<<" data[1]="<<(int)data[1]<<endl;
+    data[2 + port] = rate;
+    sendUBX(MSG_CFG_MSG, data, 8);
+    /* Ack check has to be done differently, asynchronously
+    if (waitAck(MSG_CFG_MSG, 12000)) {
+        emit toConsole("Set CFG successful");
+    }
+    else {
+        emit UBXCfgError("Set CFG timeout");
+    }
+    */
+}
+
+void QtSerialUblox::UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate, int verbose)
+{
+    uint16_t msgID = (messageID + (uint16_t)classID) << 8;
+    UBXSetCfgMsg(msgID, port, rate, verbose);
+}
+
 void QtSerialUblox::handleError(QSerialPort::SerialPortError serialPortError)
 {
     if (serialPortError == QSerialPort::ReadError) {

--- a/myon_detector/qtserialublox.cpp
+++ b/myon_detector/qtserialublox.cpp
@@ -1,11 +1,48 @@
-#include <QSerialPort>
 #include "qtserialublox.h"
+#include "custom_io_operators.h" // remove after debug
+using namespace std; //remove after debug
 
-QtSerialUblox::QtSerialUblox(const QString &serialPortName, int baudRate,
-                             QObject *parent, bool newDumpRaw, int newVerbose, QObject *parent) : QObject(parent)
+QtSerialUblox::QtSerialUblox(const QString serialPortName, int baudRate,
+                             bool newDumpRaw, int newVerbose, QObject *parent) : QObject(parent)
 {
     _portName = serialPortName;
     _baudRate = baudRate;
     verbose = newVerbose;
     dumpRaw = newDumpRaw;
+}
+
+void QtSerialUblox::makeConnection(){
+    // this function gets called with a signal from client-thread
+    // (QtSerialUblox runs in a separate thread only communicating with main thread through messages)
+    if (verbose > 2){
+        emit toConsole(QString("gps running in thread " + QString( "0x%1" ).arg( (int)this->thread(), 16 )));
+    }
+    if (serialPort){
+        delete(serialPort);
+    }
+    serialPort = new QSerialPort(_portName);
+    serialPort->setBaudRate(_baudRate);
+    if (!serialPort->open(QIODevice::ReadWrite)) {
+        emit toConsole(QObject::tr("Failed to open port %1, error: %2")
+                          .arg(_portName)
+                          .arg(serialPort->errorString()));
+        return;
+    }
+    connect(serialPort, &QSerialPort::readyRead, this, &QtSerialUblox::onReadyRead);
+}
+
+void QtSerialUblox::onReadyRead(){
+    // this function gets called when the serial port emits readyRead signal
+    QByteArray temp = serialPort->readAll();
+    emit toConsole(QString(temp));
+}
+
+void QtSerialUblox::handleError(QSerialPort::SerialPortError serialPortError)
+{
+    if (serialPortError == QSerialPort::ReadError) {
+        emit toConsole(QObject::tr("An I/O error occurred while reading "
+                                        "the data from port %1, error: %2")
+                            .arg(serialPort->portName())
+                            .arg(serialPort->errorString()));
+    }
 }

--- a/myon_detector/qtserialublox.cpp
+++ b/myon_detector/qtserialublox.cpp
@@ -229,30 +229,35 @@ void QtSerialUblox::UBXSetCfgPrt(uint8_t port, uint8_t outProtocolMask){
         // port 1 is UART port, payload for other ports may differ
         // setup payload. Bit masks are set up byte wise from lowest to highest byte
         data[0] = port; // set port (1 Byte)
-        // data[1]=0; reserved
-        // data[2]=0;data[3]=0; txReady options (not used)
+        data[1]=0; // reserved
+        data[2]=0;
+        data[3]=0; // txReady options (not used)
         // mode option:
         data[4] = 0b11000000; // charLen option (first 2 bits): 11 means 8 bit character length. (10 means 7 bit character length only with parity enabled)
         data[5] = 0b00001000; // first 2 bits unimportant. 00 -> 1 stop bit. 100 -> no parity. last bit unimportant.
-        // data[6]=0; data[7]=0; part of mode option but no meaning
+        data[6]=0;
+        data[7]=0; //part of mode option but no meaning
 
         // baudrate: (check if it works)
-        data[6] = (uint8_t)(((uint16_t)_baudRate) & 0x00ff);
-        data[7] = (uint8_t)((((uint16_t)_baudRate) & 0xff00)>>8);
-        // data[8]=0; data[9]=0; not needed because baudRate will never be over 65536 (2^16)
+        data[8] = (uint8_t)(((uint16_t)_baudRate) & 0x00ff);
+        data[9] = (uint8_t)((((uint16_t)_baudRate) & 0xff00)>>8);
+        data[10]=0;
+        data[11]=0; //not needed because baudRate will never be over 65536 (2^16)
 
         // inProtoMask enables/disables possible protocols for sending messages to the gps module:
         data[12] = 0b00100111; // () () (RTCM3) () () (RTCM) (NMEA) (UBX)
-        // data[13]=0; has no meaning but part of inProtoMask
+        data[13]=0; //has no meaning but part of inProtoMask
 
         // outProtoMask enables/disables protocols for receiving messages from the gps module:
         //data[14] = 0b00100011; // () () (RTCM3) () () () (NMEA) (UBX) FOR EXAMPLE
         data[14] = outProtocolMask;
 
-        // data[15]=0; has no meaning but part of outProtoMask
+        data[15]=0; //has no meaning but part of outProtoMask
 
-        // data[16]=0; data[17]=0; extendedTxTimeout not needed
-        // data[18]=0; data[19]=0; reserved
+        data[16]=0;
+        data[17]=0; // extendedTxTimeout not needed
+        data[18]=0;
+        data[19]=0; // reserved
     }
     sendUBX(MSG_CFG_PRT, data, 20);
 }
@@ -313,10 +318,10 @@ void QtSerialUblox::handleError(QSerialPort::SerialPortError serialPortError)
 
 void QtSerialUblox::sendPoll(uint16_t msgID, uint8_t port){
     switch (msgID){
-    case 0x0601:
-        std::string temp;
-        temp.append(port);
-        sendUBX(msgID,temp.c_str(),1);
+    case 0x0600:
+        unsigned char temp[1];
+        temp[0] = port;
+        sendUBX(msgID,temp,1);
         break;
     default:
         break;

--- a/myon_detector/qtserialublox.h
+++ b/myon_detector/qtserialublox.h
@@ -21,13 +21,13 @@ public slots:
     void makeConnection();
     void onReadyRead();
     void handleError(QSerialPort::SerialPortError serialPortError);
-    void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate, int verbose);
-    void UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate, int verbose);
+    void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate);
     void calcChkSum(const std::string& buf, unsigned char* chkA, unsigned char* chkB);
-    void UBXSetCfgRate(uint8_t measRate, uint8_t navRate, int verbose);
+    void UBXSetCfgRate(uint8_t measRate, uint8_t navRate);
 
 
 private:
+    void UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate);
     bool sendUBX(uint16_t msgID, unsigned char* payload, int nBytes);
     bool sendUBX(unsigned char classID, unsigned char messageID,
                                 unsigned char* payload, int nBytes);

--- a/myon_detector/qtserialublox.h
+++ b/myon_detector/qtserialublox.h
@@ -1,0 +1,24 @@
+#ifndef QTSERIALUBLOX_H
+#define QTSERIALUBLOX_H
+
+#include <QObject>
+
+class QtSerialUblox : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit QtSerialUblox(const QString &serialPortName = nullptr, int baudRate, QObject *parent,
+                           bool newDumpRaw, int newVerbose, QObject *parent);
+
+signals:
+
+public slots:
+private:
+    QString _portName;
+    int _baudRate = 0;
+    int verbose = 0;
+    bool dumpRaw = false;
+};
+
+#endif // QTSERIALUBLOX_H

--- a/myon_detector/qtserialublox.h
+++ b/myon_detector/qtserialublox.h
@@ -21,13 +21,13 @@ public slots:
     void makeConnection();
     void onReadyRead();
     void handleError(QSerialPort::SerialPortError serialPortError);
-    void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate);
+    void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate, int verbose);
+    void UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate, int verbose);
     void calcChkSum(const std::string& buf, unsigned char* chkA, unsigned char* chkB);
-    void UBXSetCfgRate(uint8_t measRate, uint8_t navRate);
+    void UBXSetCfgRate(uint8_t measRate, uint8_t navRate, int verbose);
 
 
 private:
-    void UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate);
     bool sendUBX(uint16_t msgID, unsigned char* payload, int nBytes);
     bool sendUBX(unsigned char classID, unsigned char messageID,
                                 unsigned char* payload, int nBytes);

--- a/myon_detector/qtserialublox.h
+++ b/myon_detector/qtserialublox.h
@@ -1,6 +1,7 @@
 #ifndef QTSERIALUBLOX_H
 #define QTSERIALUBLOX_H
 
+#include "structs_and_defines.h"
 #include <QSerialPort>
 #include <QObject>
 
@@ -14,18 +15,27 @@ public:
 
 signals:
     void toConsole(QString data);
-
+    void UBXCfgError(QString data);
 
 public slots:
     void makeConnection();
     void onReadyRead();
     void handleError(QSerialPort::SerialPortError serialPortError);
+    void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate, int verbose);
+    void UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate, int verbose);
+    void calcChkSum(const std::string& buf, unsigned char* chkA, unsigned char* chkB);
+    void UBXSetCfgRate(uint8_t measRate, uint8_t navRate, int verbose);
+
 
 private:
+    bool sendUBX(uint16_t msgID, unsigned char* payload, int nBytes);
+    bool sendUBX(unsigned char classID, unsigned char messageID,
+                                unsigned char* payload, int nBytes);
     QSerialPort *serialPort = nullptr;
     QString _portName;
     int _baudRate = 0;
     int verbose = 0;
+    int timeout = 5000;
     bool dumpRaw = false;
 };
 

--- a/myon_detector/qtserialublox.h
+++ b/myon_detector/qtserialublox.h
@@ -13,12 +13,13 @@ class QtSerialUblox : public QObject
 
 public:
     explicit QtSerialUblox(const QString serialPortName, int baudRate,
-                           bool newDumpRaw, int newVerbose, QObject *parent = 0);
+                           bool newDumpRaw, int newVerbose, bool newShowout, QObject *parent = 0);
 
 signals:
     // all messages coming from QtSerialUblox class that should be displayed on console
     // get sent to Client thread with signal/slot mechanics
     void toConsole(QString data);
+    void toConsoleNewLine(QString data);
     void UBXCfgError(QString data);
 
     // information about updated properties
@@ -83,8 +84,10 @@ private:
     int _baudRate = 0;
     int verbose = 0;
     int timeout = 5000;
-    bool dumpRaw = false;
-    bool discardAllNMEA = true;
+    bool dumpRaw = false; // if true show all messages coming from the gps board that can
+                          // be interpreted as QString by QString(message) (basically all NMEA)
+    bool discardAllNMEA = true; // if true discard all NMEA messages and do not parse them
+    bool showout = false; // if true show the ubx messages sent to the gps board as hex
 
     // all global variables used for keeping track of satellites and statistics (gpsProperty)
     gpsProperty<int> leapSeconds;

--- a/myon_detector/qtserialublox.h
+++ b/myon_detector/qtserialublox.h
@@ -39,10 +39,12 @@ public slots:
     // all functions that can be called from other classes through signal/slot mechanics
     void makeConnection();
     void onReadyRead();
-    void sendPoll(uint16_t msgID);
+    void sendPoll(uint16_t msgID, uint8_t port);
     void handleError(QSerialPort::SerialPortError serialPortError);
     void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate);
     void UBXSetCfgRate(uint8_t measRate, uint8_t navRate);
+    void UBXSetCfgPrt(uint8_t port, uint8_t outProtocolMask);
+    // outPortMask is something like 1 for only UBX protocol or 0b11 for UBX and NMEA
 
 
 private:

--- a/myon_detector/qtserialublox.h
+++ b/myon_detector/qtserialublox.h
@@ -19,7 +19,7 @@ signals:
     // all messages coming from QtSerialUblox class that should be displayed on console
     // get sent to Client thread with signal/slot mechanics
     void toConsole(QString data);
-    void toConsoleNewLine(QString data);
+    void UBXReceivedAckAckNak(uint16_t ClsMsgID, bool ackAck);
     void UBXCfgError(QString data);
 
     // information about updated properties
@@ -39,6 +39,7 @@ public slots:
     // all functions that can be called from other classes through signal/slot mechanics
     void makeConnection();
     void onReadyRead();
+    void sendPoll(uint16_t msgID);
     void handleError(QSerialPort::SerialPortError serialPortError);
     void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate);
     void UBXSetCfgRate(uint8_t measRate, uint8_t navRate);
@@ -53,9 +54,6 @@ private:
     bool sendUBX(uint16_t msgID, unsigned char* payload, int nBytes);
     bool sendUBX(unsigned char classID, unsigned char messageID,
                                 unsigned char* payload, int nBytes);
-    bool pollUBX(uint16_t msgID, std::string& answer, int timeout);
-    bool pollUBX(uint8_t classID, uint8_t messageID, std::string& answer, int timeout);
-
 
     // all functions only used for processing and showing "UbxMessage"
     void processMessage(const UbxMessage& msg);

--- a/myon_detector/qtserialublox.h
+++ b/myon_detector/qtserialublox.h
@@ -2,6 +2,8 @@
 #define QTSERIALUBLOX_H
 
 #include "structs_and_defines.h"
+#include <queue>
+#include <string>
 #include <QSerialPort>
 #include <QObject>
 
@@ -14,29 +16,93 @@ public:
                            bool newDumpRaw, int newVerbose, QObject *parent = 0);
 
 signals:
+    // all messages coming from QtSerialUblox class that should be displayed on console
+    // get sent to Client thread with signal/slot mechanics
     void toConsole(QString data);
     void UBXCfgError(QString data);
 
+    // information about updated properties
+    void gpsPropertyUpdatedUint8(uint8_t data,
+                                 std::chrono::duration<double> updateAge,
+                           char propertyName);
+    void gpsPropertyUpdatedUint32(uint32_t data,
+                                 std::chrono::duration<double> updateAge,
+                            char propertyName);
+    void gpsPropertyUpdatedInt32(int32_t data,
+                                 std::chrono::duration<double> updateAge,
+                            char propertyName);
+    void gpsPropertyUpdatedGnss(std::vector<GnssSatellite>,
+                            std::chrono::duration<double> updateAge);
+
 public slots:
+    // all functions that can be called from other classes through signal/slot mechanics
     void makeConnection();
     void onReadyRead();
     void handleError(QSerialPort::SerialPortError serialPortError);
     void UBXSetCfgMsg(uint16_t msgID, uint8_t port, uint8_t rate);
-    void calcChkSum(const std::string& buf, unsigned char* chkA, unsigned char* chkB);
     void UBXSetCfgRate(uint8_t measRate, uint8_t navRate);
 
 
 private:
-    void UBXSetCfgMsg(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate);
+    // all functions for sending and receiving raw data used by other functions in "public slots" section
+    // and scanning raw data up to the point where "UbxMessage" object is generated
+    void UBXSetCfgMsg2(uint8_t classID, uint8_t messageID, uint8_t port, uint8_t rate);
+    bool scanUnknownMessage(std::string &buffer,UbxMessage &message);
+    void calcChkSum(const std::string &buf, unsigned char* chkA, unsigned char* chkB);
     bool sendUBX(uint16_t msgID, unsigned char* payload, int nBytes);
     bool sendUBX(unsigned char classID, unsigned char messageID,
                                 unsigned char* payload, int nBytes);
+    bool pollUBX(uint16_t msgID, std::string& answer, int timeout);
+    bool pollUBX(uint8_t classID, uint8_t messageID, std::string& answer, int timeout);
+
+
+    // all functions only used for processing and showing "UbxMessage"
+    void processMessage(const UbxMessage& msg);
+    bool UBXNavClock(uint32_t& itow, int32_t& bias, int32_t& drift,
+                            uint32_t& tAccuracy, uint32_t& fAccuracy);
+    bool UBXTimTP(uint32_t& itow, int32_t& quantErr, uint16_t& weekNr);
+    bool UBXTimTP();
+    bool UBXTimTP(const std::string& msg);
+    bool UBXTimTM2(const std::string& msg);
+    std::vector<GnssSatellite> UBXNavSat(bool allSats);
+    std::vector<GnssSatellite> UBXNavSat(const std::string& msg, bool allSats);
+    bool UBXCfgGNSS();
+    bool UBXCfgNav5();
+    std::vector<std::string> UBXMonVer();
+    void UBXNavClock(const std::string& msg);
+    void UBXNavTimeGPS(const std::string& msg);
+    void UBXNavTimeUTC(const std::string& msg);
+    void UBXMonHW(const std::string& msg);
+    void UBXMonTx(const std::string& msg);
+
+
+    // all global variables used in QtSerialUblox class until UbxMessage was created
     QSerialPort *serialPort = nullptr;
     QString _portName;
+    std::string buffer = "";
     int _baudRate = 0;
     int verbose = 0;
     int timeout = 5000;
     bool dumpRaw = false;
+    bool discardAllNMEA = true;
+
+    // all global variables used for keeping track of satellites and statistics (gpsProperty)
+    gpsProperty<int> leapSeconds;
+    gpsProperty<double> noise;
+    gpsProperty<double> agc;
+    gpsProperty<uint8_t> nrSats;
+    gpsProperty<uint8_t> TPQuantErr;
+    gpsProperty<uint8_t> txBufUsage;
+    gpsProperty<uint8_t> txBufPeakUsage;
+    gpsProperty<uint32_t> timeAccuracy;
+    gpsProperty<uint32_t> eventCounter;
+    gpsProperty<int32_t> clkBias;
+    gpsProperty<int32_t> clkDrift;
+    gpsProperty<std::vector<GnssSatellite> > satList;
+    const int	MSGTIMEOUT = 1500;
+    std::queue<gpsTimestamp> fTimestamps;
+    std::list<UbxMessage> fMessageBuffer;
+
 };
 
 #endif // QTSERIALUBLOX_H

--- a/myon_detector/qtserialublox.h
+++ b/myon_detector/qtserialublox.h
@@ -1,6 +1,7 @@
 #ifndef QTSERIALUBLOX_H
 #define QTSERIALUBLOX_H
 
+#include <QSerialPort>
 #include <QObject>
 
 class QtSerialUblox : public QObject
@@ -8,13 +9,20 @@ class QtSerialUblox : public QObject
     Q_OBJECT
 
 public:
-    explicit QtSerialUblox(const QString &serialPortName = nullptr, int baudRate, QObject *parent,
-                           bool newDumpRaw, int newVerbose, QObject *parent);
+    explicit QtSerialUblox(const QString serialPortName, int baudRate,
+                           bool newDumpRaw, int newVerbose, QObject *parent = 0);
 
 signals:
+    void toConsole(QString data);
+
 
 public slots:
+    void makeConnection();
+    void onReadyRead();
+    void handleError(QSerialPort::SerialPortError serialPortError);
+
 private:
+    QSerialPort *serialPort = nullptr;
     QString _portName;
     int _baudRate = 0;
     int verbose = 0;

--- a/myon_detector/qtserialublox_processmessages.cpp
+++ b/myon_detector/qtserialublox_processmessages.cpp
@@ -102,12 +102,8 @@ void QtSerialUblox::processMessage(const UbxMessage& msg)
     case 0x06: // UBX-CFG
         switch (messageID) {
         default:
-            if (verbose > 3) {
-                tempStream << "received unhandled UBX-CFG message: 0xb5 0x62 0x"
-                           << (uint8_t)(((uint16_t)msg.data.size())&0x00ff) << " 0x"
-                           << (uint8_t)((((uint16_t)msg.data.size())&0xff00) >> 8)
-                           << std::setfill('0') << std::hex << std::setw(2) << (int)classID
-                           << " 0x" << std::setfill('0') << std::setw(2) << std::hex << (int)messageID;
+            if (verbose > 1) {
+                tempStream << "received UBX-CFG message: 0x";
                 for (std::string::size_type i = 0; i<msg.data.size(); i++){
                     tempStream << " 0x" << std::setfill('0') << std::setw(2) << std::hex << (int)msg.data[i];
                 }
@@ -283,7 +279,7 @@ bool QtSerialUblox::UBXNavClock(uint32_t& itow, int32_t& bias, int32_t& drift,
         tempStream << " clock bias    : " << dec << clkB << " ns" << endl;
         tempStream << " clock drift   : " << dec << clkD << " ns/s" << endl;
         tempStream << " time accuracy : " << dec << tAcc << " ns" << endl;
-        tempStream << " freq accuracy : " << dec << fAcc << " ps/s" << endl;
+        tempStream << " freq accuracy : " << dec << fAcc << " ps/s\n" << endl;
         //tempStream >> temp;
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -340,6 +336,7 @@ bool QtSerialUblox::UBXTimTP(uint32_t& itow, int32_t& quantErr, uint16_t& weekNr
         tempStream << " refInfo          : ";
         for (int i = 7; i >= 0; i--) if (refInfo & 1 << i) tempStream << i; else tempStream << "-";
         //tempStream >> temp;
+        tempStream << "\n";
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
     return true;
@@ -451,7 +448,7 @@ bool QtSerialUblox::UBXTimTP(const std::string& msg)
         default:
             utcStd = "unknown";
         }
-        tempStream << "  UTC standard  : " << utcStd << endl;
+        tempStream << "  UTC standard  : " << utcStd << "\n";
         //tempStream >> temp;
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -561,7 +558,7 @@ bool QtSerialUblox::UBXTimTM2(const std::string& msg)
         default:
             timeBase = "unknown";
         }
-        tempStream << "   time base            : " << timeBase;
+        tempStream << "   time base            : " << timeBase << "\n";
         //tempStream >> temp;
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -629,7 +626,7 @@ std::vector<GnssSatellite> QtSerialUblox::UBXNavSat(bool allSats)
         tempStream << " iTOW          : " << dec << iTOW / 1000 << " s" << endl;
         tempStream << " version       : " << dec << (int)version << endl;
         tempStream << " Nr of sats    : " << (int)numSvs << "  (nr of sections=" << N << ")\n";
-        tempStream << "   Sat Data :";
+        tempStream << "   Sat Data :\n";
         //tempStream >> temp;
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -644,7 +641,7 @@ std::vector<GnssSatellite> QtSerialUblox::UBXNavSat(bool allSats)
         while (satList.back().getCnr() == 0 && satList.size() > 0) satList.pop_back();
     }
 
-    if (verbose) {
+    if (verbose>0) {
         std::string temp;
         GnssSatellite::PrintHeader(true);
         for (vector<GnssSatellite>::iterator it = satList.begin(); it != satList.end(); it++) {
@@ -653,7 +650,7 @@ std::vector<GnssSatellite> QtSerialUblox::UBXNavSat(bool allSats)
         std::stringstream tempStream;
         tempStream << "   --------------------------------------------------------------------\n";
         if (verbose > 1){
-            tempStream << " Nr of avail sats : " << goodSats;
+            tempStream << " Nr of avail sats : \n" << goodSats;
         }
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -684,7 +681,7 @@ std::vector<GnssSatellite> QtSerialUblox::UBXNavSat(const std::string& msg, bool
         tempStream << " iTOW          : " << dec << iTOW / 1000 << " s" << endl;
         tempStream << " version       : " << dec << (int)version << endl;
         tempStream << " Nr of sats    : " << (int)numSvs << "  (nr of sections=" << N << ")\n";
-        tempStream << "   Sat Data :";
+        tempStream << "   Sat Data :\n";
         //tempStream >> temp;
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -714,7 +711,7 @@ std::vector<GnssSatellite> QtSerialUblox::UBXNavSat(const std::string& msg, bool
         std::stringstream tempStream;
         tempStream << "   --------------------------------------------------------------------\n";
         if (verbose > 1){
-            tempStream << " Nr of avail sats : " << goodSats;
+            tempStream << " Nr of avail sats : " << goodSats << "\n";
         }
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -747,7 +744,7 @@ bool QtSerialUblox::UBXCfgGNSS()
         tempStream << " nr of channels in use      : " << dec << (int)numTrkChUse << endl;
         tempStream << " Nr of config blocks        : " << (int)numConfigBlocks
                    << "  (nr of sections=" << N << ")";
-        tempStream << "  Config Data :";
+        tempStream << "  Config Data :\n";
         //tempStream >> temp;
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -771,7 +768,7 @@ bool QtSerialUblox::UBXCfgGNSS()
                        << dec << (int)resTrkCh << endl;
             tempStream << "      max nr of tracking channels used : "
                        << dec << (int)maxTrkCh << endl;
-            tempStream << "      flags  : " << std::hex << (int)flags;
+            tempStream << "      flags  : " << std::hex << (int)flags << "\n";
             //tempStream >> temp;
             emit toConsole(QString::fromStdString(tempStream.str()));
         }
@@ -812,7 +809,7 @@ bool QtSerialUblox::UBXCfgNav5()
         tempStream << " fixMode            : " << dec << (int)fixMode << endl;
         tempStream << " fixed Alt          : " << (double)fixedAlt*0.01 << " m" << endl;
         tempStream << " fixed Alt Var      : " << (double)fixedAltVar*0.0001 << " m^2" << endl;
-        tempStream << " min elevation      : " << dec << (int)minElev << " deg";
+        tempStream << " min elevation      : " << dec << (int)minElev << " deg\n";
         //tempStream >> temp;
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -911,7 +908,7 @@ void QtSerialUblox::UBXNavClock(const std::string& msg)
         tempStream << " clock bias    : " << dec << clkB << " ns" << endl;
         tempStream << " clock drift   : " << dec << clkD << " ns/s" << endl;
         tempStream << " time accuracy : " << dec << tAcc << " ns" << endl;
-        tempStream << " freq accuracy : " << dec << fAcc << " ps/s";
+        tempStream << " freq accuracy : " << dec << fAcc << " ps/s\n";
         //tempStream >> temp;
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -986,7 +983,7 @@ void QtSerialUblox::UBXNavTimeGPS(const std::string& msg)
     struct timespec ts = unixtime_from_gps(wnR, iTOW / 1000, (long int)(sr*1e9 + fTOW)/*, this->leapSeconds()*/);
     std::stringstream tempStream;
     //std::string temp;
-    tempStream << ts.tv_sec << '.' << ts.tv_nsec;
+    tempStream << ts.tv_sec << '.' << ts.tv_nsec << "\n";
     //tempStream >> temp;
     emit toConsole(QString::fromStdString(tempStream.str()));
 }
@@ -1082,7 +1079,7 @@ void QtSerialUblox::UBXNavTimeUTC(const std::string& msg)
         default:
             utcStd = "unknown";
         }
-        tempStream << "   UTC standard  : " << utcStd;
+        tempStream << "   UTC standard  : " << utcStd << "\n";
         //tempStream >> temp;
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
@@ -1124,6 +1121,7 @@ void QtSerialUblox::UBXMonHW(const std::string& msg)
         tempStream << "   jamming state    : " << (int)((flags & 0x0c) >> 2) << endl;
         tempStream << "   Xtal absent      : " << string((flags & 0x10) ? "yes" : "no");
         //tempStream >> temp;
+        tempStream << "\n";
         emit toConsole(QString::fromStdString(tempStream.str()));
     }
 }
@@ -1185,7 +1183,8 @@ void QtSerialUblox::UBXMonTx(const std::string& msg)
         for (int i = 0; i < 6; i++) {
             tempStream << "    (" << dec << i << ") " << setw(3) << pending[i];
         }
-        tempStream << setw(1) << setfill(' ');
+        tempStream << "\n";
+        //tempStream << setw(1) << setfill(' ');
         //tempStream >> temp;
         emit toConsole(QString::fromStdString(tempStream.str()));
     }

--- a/myon_detector/qtserialublox_processmessages.cpp
+++ b/myon_detector/qtserialublox_processmessages.cpp
@@ -1,0 +1,1118 @@
+#include <sstream>
+#include <QThread>
+#include "qtserialublox.h"
+#include "unixtime_from_gps.h"
+
+using namespace std;
+
+// all about processing different ubx-messages:
+void QtSerialUblox::processMessage(const UbxMessage& msg)
+{
+    uint8_t classID = (msg.msgID & 0xff00) >> 8;
+    uint8_t messageID = msg.msgID & 0xff;
+
+    std::vector<GnssSatellite> sats;
+    std::stringstream tempStream;
+    //std::string temp;
+
+    switch (classID) {
+    case 0x01: // UBX-NAV
+        switch (messageID) {
+        case 0x20:
+            if (verbose) {
+                tempStream << "received UBX-NAV-TIMEGPS message (" << hex
+                           << (int)classID << " " << hex << (int)messageID << ")";
+            }
+            UBXNavTimeGPS(msg.data);
+            break;
+        case 0x21:
+            if (verbose) {
+                tempStream << "received UBX-NAV-TIMEUTC message (" << hex
+                           << (int)classID << " " << hex << (int)messageID << ")";
+            }
+            UBXNavTimeUTC(msg.data);
+            break;
+        case 0x22:
+            if (verbose) {
+                tempStream << "received UBX-NAV-CLOCK message (" << hex
+                           << (int)classID << " " << hex << (int)messageID << ")" << endl;
+            }
+            UBXNavClock(msg.data);
+            break;
+        case 0x35:
+            sats = UBXNavSat(msg.data, true);
+            if (verbose) {
+                tempStream << "received UBX-NAV-SAT message (" << hex << (int)classID
+                           << " " << hex << (int)messageID << ")" << endl;
+            }
+            //mutex.lock();
+            emit gpsPropertyUpdatedGnss(sats, satList.updateAge());
+            satList = sats;
+            //mutex.unlock();
+            //break;
+//				tempStream<<"Satellite List: "<<sats.size()<<" sats received"<<endl;
+// 				GnssSatellite::PrintHeader(true);
+// 				for (int i=0; i<sats.size(); i++) sats[i].Print(i, false);
+            break;
+        default:
+            if (verbose) {
+                tempStream << "received unhandled UBX-NAV message (" << hex << (int)classID
+                           << " " << hex << (int)messageID << ")" << endl;
+            }
+        }
+        break;
+    case 0x02: // UBX-RXM
+        break;
+    case 0x05: // UBX-ACK
+        break;
+    case 0x0b: // UBX-AID
+        break;
+    case 0x06: // UBX-CFG
+        switch (messageID) {
+        default:
+            if (verbose) {
+                tempStream << "received unhandled UBX-CFG message (" << hex << (int)classID
+                           << " " << hex << (int)messageID << ")" << endl;
+            }
+        }
+        break;
+    case 0x10: // UBX-ESF
+        break;
+    case 0x28: // UBX-HNR
+        break;
+    case 0x04: // UBX-INF
+        switch (messageID) {
+        default:
+            if (verbose) {
+                tempStream << "received unhandled UBX-INF message (" << hex << (int)classID
+                           << " " << hex << (int)messageID << ")" << endl;
+            }
+        }
+        break;
+    case 0x21: // UBX-LOG
+        break;
+    case 0x13: // UBX-MGA
+        break;
+    case 0x0a: // UBX-MON
+        switch (messageID) {
+        case 0x08:
+            if (verbose) {
+                tempStream << "received UBX-MON-TXBUF message (" << hex << (int)classID
+                           << " " << hex << (int)messageID << ")" << endl;
+            }
+            UBXMonTx(msg.data);
+            break;
+        case 0x09:
+            if (verbose) {
+                tempStream << "received UBX-MON-HW message (" << hex << (int)classID
+                           << " " << hex << (int)messageID << ")" << endl;
+            }
+            UBXMonHW(msg.data);
+            break;
+        default:
+            if (verbose) {
+                tempStream << "received unhandled UBX-MON message (" << hex << (int)classID
+                           << " " << hex << (int)messageID << ")" << endl;
+            }
+        }
+        break;
+    case 0x27: // UBX-SEC
+        break;
+    case 0x0d: // UBX-TIM
+        switch (messageID) {
+        case 0x01: // UBX-TIM-TP
+            if (verbose) {
+                tempStream << "received UBX-TIM-TP message (" << hex << (int)classID << " "
+                           << hex << (int)messageID << ")" << endl;
+            }
+            UBXTimTP(msg.data);
+            break;
+        case 0x03: // UBX-TIM-TM2
+            if (verbose) {
+                tempStream << "received UBX-TIM-TM2 message (" << hex << (int)classID << " "
+                           << hex << (int)messageID << ")" << endl;
+            }
+            UBXTimTM2(msg.data);
+            break;
+        default:
+            if (verbose) {
+                tempStream << "received unhandled UBX-TIM message (" << hex << (int)classID
+                           << " " << hex << (int)messageID << ")" << endl;
+            }
+        }
+        break;
+    case 0x09: // UBX-UPD
+        break;
+    default: break;
+    }
+    //tempStream >> temp;
+    emit toConsole(QString::fromStdString(tempStream.str()));
+}
+
+
+bool QtSerialUblox::UBXNavClock(uint32_t& itow, int32_t& bias, int32_t& drift,
+                        uint32_t& tAccuracy, uint32_t& fAccuracy)
+{
+    // why tAccuracy?
+    tAccuracy=0;
+    std::string answer;
+    // UBX-NAV-CLOCK: clock solution
+    bool ok = pollUBX(MSG_NAV_CLOCK, answer, MSGTIMEOUT);
+    if (!ok) return ok;
+    //return true;
+    // parse all fields
+    // GPS time of week
+    uint32_t iTOW = (int)answer[0];
+    iTOW += ((int)answer[1]) << 8;
+    iTOW += ((int)answer[2]) << 16;
+    iTOW += ((int)answer[3]) << 24;
+    itow = iTOW / 1000;
+    // clock bias
+    if (verbose > 3) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "clkB[0]=" << hex << (int)answer[4] << endl;
+        tempStream << "clkB[1]=" << hex << (int)answer[5] << endl;
+        tempStream << "clkB[2]=" << hex << (int)answer[6] << endl;
+        tempStream << "clkB[3]=" << hex << (int)answer[7] << endl;
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    int32_t clkB = (int)answer[4];
+    clkB += ((int)answer[5]) << 8;
+    clkB += ((int)answer[6]) << 16;
+    clkB += ((int)answer[7]) << 24;
+    bias = clkB;
+    // clock drift
+    int32_t clkD = (int)answer[8];
+    clkD += ((int)answer[9]) << 8;
+    clkD += ((int)answer[10]) << 16;
+    clkD += ((int)answer[11]) << 24;
+    drift = clkD;
+    // time accuracy estimate
+    uint32_t tAcc = (int)answer[12];
+    tAcc += ((int)answer[13]) << 8;
+    tAcc += ((int)answer[14]) << 16;
+    tAcc += ((int)answer[15]) << 24;
+    //  tAccuracy=tAcc;
+      // freq accuracy estimate
+    uint32_t fAcc = (int)answer[16];
+    fAcc += ((int)answer[17]) << 8;
+    fAcc += ((int)answer[18]) << 16;
+    fAcc += ((int)answer[19]) << 24;
+    fAccuracy = fAcc;
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX-NAV-CLOCK message:" << endl;
+        tempStream << " iTOW          : " << dec << iTOW / 1000 << " s" << endl;
+        tempStream << " clock bias    : " << dec << clkB << " ns" << endl;
+        tempStream << " clock drift   : " << dec << clkD << " ns/s" << endl;
+        tempStream << " time accuracy : " << dec << tAcc << " ns" << endl;
+        tempStream << " freq accuracy : " << dec << fAcc << " ps/s" << endl;
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    return ok;
+}
+
+bool QtSerialUblox::UBXTimTP(uint32_t& itow, int32_t& quantErr, uint16_t& weekNr)
+{
+    std::string answer;
+    // UBX-TIM-TP: time pulse timedata
+    bool ok = pollUBX(MSG_TIM_TP, answer, MSGTIMEOUT);
+    if (!ok) return ok;
+    // parse all fields
+    // TP time of week, ms
+    uint32_t towMS = (int)answer[0];
+    towMS += ((int)answer[1]) << 8;
+    towMS += ((int)answer[2]) << 16;
+    towMS += ((int)answer[3]) << 24;
+    // TP time of week, sub ms
+    uint32_t towSubMS = (int)answer[4];
+    towSubMS += ((int)answer[5]) << 8;
+    towSubMS += ((int)answer[6]) << 16;
+    towSubMS += ((int)answer[7]) << 24;
+    itow = towMS / 1000;
+    // quantization error
+    int32_t qErr = (int)answer[8];
+    qErr += ((int)answer[9]) << 8;
+    qErr += ((int)answer[10]) << 16;
+    qErr += ((int)answer[11]) << 24;
+    quantErr = qErr;
+    // week number
+    uint16_t week = (int)answer[12];
+    week += ((int)answer[13]) << 8;
+    weekNr = week;
+    // flags
+    uint8_t flags = answer[14];
+    // ref info
+    uint8_t refInfo = answer[15];
+
+    double sr = towMS / 1000.;
+    sr = sr - towMS / 1000;
+
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX-TIM-TP message:" << endl;
+        tempStream << " tow s            : " << dec << towMS / 1000. << " s" << endl;
+        tempStream << " tow sub s        : " << dec << towSubMS << " = " << (long int)(sr*1e9 + towSubMS + 0.5) << " ns" << endl;
+        tempStream << " quantization err : " << dec << qErr << " ps" << endl;
+        tempStream << " week nr          : " << dec << week << endl;
+        tempStream << " flags            : ";
+        for (int i = 7; i >= 0; i--) if (flags & 1 << i) tempStream << i; else tempStream << "-";
+        tempStream << endl;
+        tempStream << " refInfo          : ";
+        for (int i = 7; i >= 0; i--) if (refInfo & 1 << i) tempStream << i; else tempStream << "-";
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    return ok;
+}
+
+bool QtSerialUblox::UBXTimTP()
+{
+    std::string answer;
+    // UBX-TIM-TP: time pulse timedata
+    bool ok = pollUBX(MSG_TIM_TP, answer, MSGTIMEOUT);
+    if (!ok) return ok;
+    UBXTimTP(answer);
+    return ok;
+}
+
+bool QtSerialUblox::UBXTimTP(const std::string& msg)
+{
+    // parse all fields
+    // TP time of week, ms
+    uint32_t towMS = (int)msg[0];
+    towMS += ((int)msg[1]) << 8;
+    towMS += ((int)msg[2]) << 16;
+    towMS += ((int)msg[3]) << 24;
+    // TP time of week, sub ms
+    uint32_t towSubMS = (int)msg[4];
+    towSubMS += ((int)msg[5]) << 8;
+    towSubMS += ((int)msg[6]) << 16;
+    towSubMS += ((int)msg[7]) << 24;
+    //int itow = towMS / 1000;
+    // quantization error
+    int32_t qErr = (int)msg[8];
+    qErr += ((int)msg[9]) << 8;
+    qErr += ((int)msg[10]) << 16;
+    qErr += ((int)msg[11]) << 24;
+    //int quantErr = qErr;
+    //mutex.lock();
+    emit gpsPropertyUpdatedInt32(qErr,TPQuantErr.updateAge(),'e');
+    TPQuantErr = qErr;
+    //mutex.unlock();
+    // week number
+    uint16_t week = (int)msg[12];
+    week += ((int)msg[13]) << 8;
+    //int weekNr = week;
+    // flags
+    uint8_t flags = msg[14];
+    // ref info
+    uint8_t refInfo = msg[15];
+
+    double sr = towMS / 1000.;
+    sr = sr - towMS / 1000;
+
+    //   cout<<"0d 01 "<<dec<<weekNr<<" "<<towMS/1000<<" "<<(long int)(sr*1e9+towSubMS+0.5)<<" "<<qErr<<flush<<endl;
+
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX-TIM-TP message:" << endl;
+        tempStream << " tow s            : " << dec << towMS / 1000. << " s" << endl;
+        tempStream << " tow sub s        : " << dec << towSubMS << " = " << (long int)(sr*1e9 + towSubMS + 0.5) << " ns" << endl;
+        tempStream << " quantization err : " << dec << qErr << " ps" << endl;
+        tempStream << " week nr          : " << dec << week << endl;
+        tempStream << " *flags            : ";
+        for (int i = 7; i >= 0; i--) if (flags & 1 << i) tempStream << i; else tempStream << "-";
+        tempStream << endl;
+        tempStream << "  time base     : " << string(((flags & 1) ? "UTC" : "GNSS")) << endl;
+        tempStream << "  UTC available : " << string((flags & 2) ? "yes" : "no") << endl;
+        tempStream << "  (T)RAIM info  : " << (int)((flags & 0x0c) >> 2) << endl;
+        tempStream << " *refInfo          : ";
+        for (int i = 7; i >= 0; i--) if (refInfo & 1 << i) tempStream << i; else tempStream << "-";
+        tempStream << endl;
+        string gnssRef;
+        switch (refInfo & 0x0f) {
+        case 0:
+            gnssRef = "GPS";
+            break;
+        case 1:
+            gnssRef = "GLONASS";
+            break;
+        case 2:
+            gnssRef = "BeiDou";
+            break;
+        default:
+            gnssRef = "unknown";
+        }
+        tempStream << "  GNSS reference : " << gnssRef << endl;
+        string utcStd;
+        switch ((refInfo & 0xf0) >> 4) {
+        case 0:
+            utcStd = "n/a";
+            break;
+        case 1:
+            utcStd = "CRL";
+            break;
+        case 2:
+            utcStd = "NIST";
+            break;
+        case 3:
+            utcStd = "USNO";
+            break;
+        case 4:
+            utcStd = "BIPM";
+            break;
+        case 5:
+            utcStd = "EU";
+            break;
+        case 6:
+            utcStd = "SU";
+            break;
+        default:
+            utcStd = "unknown";
+        }
+        tempStream << "  UTC standard  : " << utcStd << endl;
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    return true;
+}
+
+bool QtSerialUblox::UBXTimTM2(const std::string& msg)
+{
+    // parse all fields
+    // channel
+    uint8_t ch = msg[0];
+    // flags
+    uint8_t flags = msg[1];
+    // rising edge counter
+    uint16_t count = (int)msg[2];
+    count += ((int)msg[3]) << 8;
+    // week number of last rising edge
+    uint16_t wnR = (int)msg[4];
+    wnR += ((int)msg[5]) << 8;
+    // week number of last falling edge
+    uint16_t wnF = (int)msg[6];
+    wnF += ((int)msg[7]) << 8;
+    // time of week of rising edge, ms
+    uint32_t towMsR = (int)msg[8];
+    towMsR += ((int)msg[9]) << 8;
+    towMsR += ((int)msg[10]) << 16;
+    towMsR += ((int)msg[11]) << 24;
+    // time of week of rising edge, sub ms
+    uint32_t towSubMsR = (int)msg[12];
+    towSubMsR += ((int)msg[13]) << 8;
+    towSubMsR += ((int)msg[14]) << 16;
+    towSubMsR += ((int)msg[15]) << 24;
+    // time of week of falling edge, ms
+    uint32_t towMsF = (int)msg[16];
+    towMsF += ((int)msg[17]) << 8;
+    towMsF += ((int)msg[18]) << 16;
+    towMsF += ((int)msg[19]) << 24;
+    // time of week of falling edge, sub ms
+    uint32_t towSubMsF = (int)msg[20];
+    towSubMsF += ((int)msg[21]) << 8;
+    towSubMsF += ((int)msg[22]) << 16;
+    towSubMsF += ((int)msg[23]) << 24;
+    // accuracy estimate
+    uint32_t accEst = (int)msg[24];
+    accEst += ((int)msg[25]) << 8;
+    accEst += ((int)msg[26]) << 16;
+    accEst += ((int)msg[27]) << 24;
+
+    //mutex.lock();
+    emit gpsPropertyUpdatedUint32(accEst, timeAccuracy.updateAge(), 'a');
+    timeAccuracy = accEst;
+    timeAccuracy.lastUpdate = std::chrono::system_clock::now();
+    //mutex.unlock();
+
+    double sr = towMsR / 1000.;
+    sr = sr - towMsR / 1000;
+    //  sr*=1000.;
+    double sf = towMsF / 1000.;
+    sf = sf - towMsF / 1000;
+    //  sf*=1000.;
+    //  cout<<"sr="<<sr<<" sf="<<sf<<endl;
+
+      // meaning of columns:
+      // 0d 03 - signature of TIM-TM2 message
+      // ch, week nr, second in current week (rising), ns of timestamp in current second (rising),
+      // second in current week (falling), ns of timestamp in current second (falling),
+      // accuracy (ns), rising edge counter, rising/falling edge (1/0), time valid (GNSS fix)
+    //   cout<<"0d 03 "<<dec<<(int)ch<<" "<<wnR<<" "<<towMsR/1000<<" "<<(long int)(sr*1e9+towSubMsR)<<" "<<towMsF/1000<<" "<<(long int)(sf*1e9+towSubMsF)<<" "<<accEst<<" "<<count<<" "<<string((flags&0x80)?"1":"0")<<" "<<string((flags&0x40)?"1":"0")<<flush;
+    //   cout<<endl;
+    //  cout<<flush;
+
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX-TimTM2 message:" << endl;
+        tempStream << " channel         : " << dec << (int)ch << endl;
+        tempStream << " rising edge ctr : " << dec << count << endl;
+        tempStream << " * last rising edge:" << endl;
+        tempStream << "    week nr        : " << dec << wnR << endl;
+        tempStream << "    tow s          : " << dec << towMsR / 1000. << " s" << endl;
+        tempStream << "    tow sub s     : " << dec << towSubMsR << " = " << (long int)(sr*1e9 + towSubMsR) << " ns" << endl;
+        tempStream << " * last falling edge:" << endl;
+        tempStream << "    week nr        : " << dec << wnF << endl;
+        tempStream << "    tow s          : " << dec << towMsF / 1000. << " s" << endl;
+        tempStream << "    tow sub s      : " << dec << towSubMsF << " = " << (long int)(sf*1e9 + towSubMsF) << " ns" << endl;
+        tempStream << " accuracy est      : " << dec << accEst << " ns" << endl;
+        tempStream << " flags             : ";
+        for (int i = 7; i >= 0; i--) if (flags & 1 << i) tempStream << i; else tempStream << "-";
+        tempStream << endl;
+        tempStream << "   mode                 : " << string((flags & 1) ? "single" : "running") << endl;
+        tempStream << "   run                  : " << string((flags & 2) ? "armed" : "stopped") << endl;
+        tempStream << "   new rising edge      : " << string((flags & 0x80) ? "yes" : "no") << endl;
+        tempStream << "   new falling edge     : " << string((flags & 0x04) ? "yes" : "no") << endl;
+        tempStream << "   UTC available        : " << string((flags & 0x20) ? "yes" : "no") << endl;
+        tempStream << "   time valid (GNSS fix): " << string((flags & 0x40) ? "yes" : "no") << endl;
+        string timeBase;
+        switch ((flags & 0x18) >> 3) {
+        case 0:
+            timeBase = "receiver time";
+            break;
+        case 1:
+            timeBase = "GNSS";
+            break;
+        case 2:
+            timeBase = "UTC";
+            break;
+        default:
+            timeBase = "unknown";
+        }
+        tempStream << "   time base            : " << timeBase;
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+
+    struct timespec ts_r = unixtime_from_gps(wnR, towMsR / 1000, (long int)(sr*1e9 + towSubMsR)/*, this->leapSeconds()*/);
+    struct timespec ts_f = unixtime_from_gps(wnF, towMsF / 1000, (long int)(sf*1e9 + towSubMsF)/*, this->leapSeconds()*/);
+
+    struct gpsTimestamp ts;
+    ts.rising_time = ts_r;
+    ts.falling_time = ts_f;
+    ts.valid = (flags & 0x40);
+    ts.channel = ch;
+
+    //   fTimestamps.push(ts);
+    ts.counter = count;
+    ts.accuracy_ns = accEst;
+
+    ts.rising = ts.falling = false;
+    if (flags & 0x80) {
+        // new rising edge detected
+        ts.rising = true;
+
+
+    } if (flags & 0x04) {
+        // new falling edge detected
+        ts.falling = true;
+
+    }
+    //mutex.lock();
+    emit gpsPropertyUpdatedUint32(count, eventCounter.updateAge(),'c');
+    eventCounter = count;
+    fTimestamps.push(ts);
+    //mutex.unlock();
+
+    return true;
+}
+
+std::vector<GnssSatellite> QtSerialUblox::UBXNavSat(bool allSats)
+{
+    std::string answer;
+    std::vector<GnssSatellite> satList;
+    // UBX-NAV-SAT: satellite information
+    bool ok = pollUBX(MSG_NAV_SAT, answer, MSGTIMEOUT);
+    //  bool ok=pollUBX(0x0d, 0x03, 0, answer, MSGTIMEOUT);
+    if (!ok) return satList;
+
+    return UBXNavSat(answer, allSats);
+
+    // parse all fields
+    // GPS time of week
+    uint32_t iTOW = (int)answer[0];
+    iTOW += ((int)answer[1]) << 8;
+    iTOW += ((int)answer[2]) << 16;
+    iTOW += ((int)answer[3]) << 24;
+    // version
+    uint8_t version = answer[4];
+    uint8_t numSvs = answer[5];
+
+    int N = (answer.size() - 8) / 12;
+
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX-NAV-SAT message:" << endl;
+        tempStream << " iTOW          : " << dec << iTOW / 1000 << " s" << endl;
+        tempStream << " version       : " << dec << (int)version << endl;
+        tempStream << " Nr of sats    : " << (int)numSvs << "  (nr of sections=" << N << ")" << endl;
+        tempStream << "   Sat Data :";
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    int goodSats = 0;
+    for (int i = 0; i < N; i++) {
+        GnssSatellite sat(answer.substr(8 + 12 * i, 12));
+        if (sat.getCnr() > 0) goodSats++;
+        satList.push_back(sat);
+    }
+    if (!allSats) {
+        sort(satList.begin(), satList.end(), GnssSatellite::sortByCnr);
+        while (satList.back().getCnr() == 0 && satList.size() > 0) satList.pop_back();
+    }
+
+    if (verbose) {
+        std::string temp;
+        GnssSatellite::PrintHeader(true);
+        for (vector<GnssSatellite>::iterator it = satList.begin(); it != satList.end(); it++) {
+            it->Print(distance(satList.begin(), it), false);
+        }
+        std::stringstream tempStream;
+        tempStream << "   --------------------------------------------------------------------\n";
+        if (verbose > 1){
+            tempStream << " Nr of avail sats : " << goodSats;
+        }
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    return satList;
+}
+
+std::vector<GnssSatellite> QtSerialUblox::UBXNavSat(const std::string& msg, bool allSats)
+{
+    std::vector<GnssSatellite> satList;
+    // UBX-NAV-SAT: satellite information
+    // parse all fields
+    // GPS time of week
+    uint32_t iTOW = (int)msg[0];
+    iTOW += ((int)msg[1]) << 8;
+    iTOW += ((int)msg[2]) << 16;
+    iTOW += ((int)msg[3]) << 24;
+    // version
+    uint8_t version = msg[4];
+    uint8_t numSvs = msg[5];
+
+    int N = (msg.size() - 8) / 12;
+
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << setfill(' ') << setw(3);
+        tempStream << "*** UBX-NAV-SAT message:" << endl;
+        tempStream << " iTOW          : " << dec << iTOW / 1000 << " s" << endl;
+        tempStream << " version       : " << dec << (int)version << endl;
+        tempStream << " Nr of sats    : " << (int)numSvs << "  (nr of sections=" << N << ")" << endl;
+        tempStream << "   Sat Data :";
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    uint8_t goodSats = 0;
+    for (int i = 0; i < N; i++) {
+        GnssSatellite sat(msg.substr(8 + 12 * i, 12));
+        if (sat.getCnr() > 0) goodSats++;
+        satList.push_back(sat);
+    }
+    if (!allSats) {
+        sort(satList.begin(), satList.end(), GnssSatellite::sortByCnr);
+        while (satList.back().getCnr() == 0 && satList.size() > 0) satList.pop_back();
+    }
+
+    //  nrSats = satList.size();
+    //mutex.lock();
+    emit gpsPropertyUpdatedUint8(goodSats,nrSats.updateAge(),'s');
+    nrSats = goodSats;
+    //mutex.unlock();
+
+    if (verbose) {
+        std::string temp;
+        GnssSatellite::PrintHeader(true);
+        for (vector<GnssSatellite>::iterator it = satList.begin(); it != satList.end(); it++) {
+            it->Print(distance(satList.begin(), it), false);
+        }
+        std::stringstream tempStream;
+        tempStream << "   --------------------------------------------------------------------\n";
+        if (verbose > 1){
+            tempStream << " Nr of avail sats : " << goodSats;
+        }
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    return satList;
+}
+
+
+bool QtSerialUblox::UBXCfgGNSS()
+{
+    std::string answer;
+    // UBX-CFG-GNSS: GNSS configuration
+    bool ok = pollUBX(MSG_CFG_GNSS, answer, MSGTIMEOUT);
+    if (!ok) return false;
+    // parse all fields
+    // version
+    uint8_t version = answer[0];
+    uint8_t numTrkChHw = answer[1];
+    uint8_t numTrkChUse = answer[2];
+    uint8_t numConfigBlocks = answer[3];
+
+    int N = (answer.size() - 4) / 8;
+
+    //  if (verbose>1)
+    {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX CFG-GNSS message:" << endl;
+        tempStream << " version                    : " << dec << (int)version << endl;
+        tempStream << " nr of hw tracking channels : " << dec << (int)numTrkChHw << endl;
+        tempStream << " nr of channels in use      : " << dec << (int)numTrkChUse << endl;
+        tempStream << " Nr of config blocks        : " << (int)numConfigBlocks
+                   << "  (nr of sections=" << N << ")";
+        tempStream << "  Config Data :";
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    for (int i = 0; i < N; i++) {
+        uint8_t gnssID = answer[4 + 8 * i];
+        uint8_t resTrkCh = answer[5 + 8 * i];
+        uint8_t maxTrkCh = answer[6 + 8 * i];
+        uint32_t flags = answer[8 + 8 * i];
+        flags |= (int)answer[9 + 8 * i] << 8;
+        flags |= (int)answer[10 + 8 * i] << 16;
+        flags |= (int)answer[11 + 8 * i] << 24;
+        //    if (verbose>1)
+        {
+            std::stringstream tempStream;
+            //std::string temp;
+            //mutex.lock();
+            tempStream << "   " << i << ":   GNSS name : "
+                       << GnssSatellite::GNSS_ID_STRING[gnssID] << endl;
+            //mutex.unlock();
+            tempStream << "      reserved (min) tracking channels  : "
+                       << dec << (int)resTrkCh << endl;
+            tempStream << "      max nr of tracking channels used : "
+                       << dec << (int)maxTrkCh << endl;
+            tempStream << "      flags  : " << hex << (int)flags;
+            //tempStream >> temp;
+            emit toConsole(QString::fromStdString(tempStream.str()));
+        }
+    }
+    return true;
+}
+
+bool QtSerialUblox::UBXCfgNav5()
+{
+    std::string answer;
+    // UBX CFG-NAV5: satellite information
+    bool ok = pollUBX(MSG_CFG_NAV5, answer, MSGTIMEOUT);
+    if (!ok) return false;
+    // parse all fields
+    // version
+    uint16_t mask = answer[0];
+    mask |= (int)answer[1] << 8;
+    uint8_t dynModel = answer[2];
+    uint8_t fixMode = answer[3];
+    int32_t fixedAlt = answer[4];
+    fixedAlt |= (int)answer[5] << 8;
+    fixedAlt |= (int)answer[6] << 16;
+    fixedAlt |= (int)answer[7] << 24;
+    uint32_t fixedAltVar = answer[8];
+    fixedAltVar |= (int)answer[9] << 8;
+    fixedAltVar |= (int)answer[10] << 16;
+    fixedAltVar |= (int)answer[11] << 24;
+    int8_t minElev = answer[12];
+
+
+    //  if (verbose>1)
+    {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX CFG-NAV5 message:" << endl;
+        tempStream << " mask               : " << hex << (int)mask << endl;
+        tempStream << " dynamic model used : " << dec << (int)dynModel << endl;
+        tempStream << " fixMode            : " << dec << (int)fixMode << endl;
+        tempStream << " fixed Alt          : " << (double)fixedAlt*0.01 << " m" << endl;
+        tempStream << " fixed Alt Var      : " << (double)fixedAltVar*0.0001 << " m^2" << endl;
+        tempStream << " min elevation      : " << dec << (int)minElev << " deg";
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    return true;
+}
+
+std::vector<std::string> QtSerialUblox::UBXMonVer()
+{
+    std::string answer;
+    std::vector<std::string> result;
+    // UBX CFG-NAV5: satellite information
+    bool ok = pollUBX(MSG_MON_VER, answer, MSGTIMEOUT);
+    if (!ok) return result;
+    // parse all fields
+    // version
+    cout << "*** UBX MON-VER message:" << endl;
+    //  cout<<answer<<endl;
+    std::string::size_type i = 0;
+    while (i != std::string::npos && i < answer.size()) {
+        std::string s = answer.substr(i, answer.find((char)0x00, i + 1) - i + 1);
+        while (s.size() && s[0] == 0x00) {
+            s.erase(0, 1);
+        }
+        if (s.size()) {
+            result.push_back(s);
+            emit toConsole(QString::fromStdString(s));
+        }
+        i = answer.find((char)0x00, i + 1);
+    }
+    return result;
+}
+
+
+void QtSerialUblox::UBXNavClock(const std::string& msg)
+{
+    // parse all fields
+    // GPS time of week
+    uint32_t iTOW = (int)msg[0];
+    iTOW += ((int)msg[1]) << 8;
+    iTOW += ((int)msg[2]) << 16;
+    iTOW += ((int)msg[3]) << 24;
+    //uint32_t itow = iTOW / 1000;
+    // clock bias
+    if (verbose > 3) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "clkB[0]=" << hex << (int)msg[4] << endl;
+        tempStream << "clkB[1]=" << hex << (int)msg[5] << endl;
+        tempStream << "clkB[2]=" << hex << (int)msg[6] << endl;
+        tempStream << "clkB[3]=" << hex << (int)msg[7];
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    int32_t clkB = (int)msg[4];
+    clkB += ((int)msg[5]) << 8;
+    clkB += ((int)msg[6]) << 16;
+    clkB += ((int)msg[7]) << 24;
+    //int32_t bias = clkB;
+    // clock drift
+    int32_t clkD = (int)msg[8];
+    clkD += ((int)msg[9]) << 8;
+    clkD += ((int)msg[10]) << 16;
+    clkD += ((int)msg[11]) << 24;
+    //int32_t drift = clkD;
+    //mutex.lock();
+    emit gpsPropertyUpdatedInt32(clkD,clkDrift.updateAge(),'d');
+    emit gpsPropertyUpdatedInt32(clkB,clkBias.updateAge(),'b');
+    clkDrift = clkD;
+    clkBias = clkB;
+    //mutex.unlock();
+    // time accuracy estimate
+    uint32_t tAcc = (int)msg[12];
+    tAcc += ((int)msg[13]) << 8;
+    tAcc += ((int)msg[14]) << 16;
+    tAcc += ((int)msg[15]) << 24;
+    //uint32_t tAccuracy = tAcc;
+    //timeAccuracy = tAcc;
+    // freq accuracy estimate
+    uint32_t fAcc = (int)msg[16];
+    fAcc += ((int)msg[17]) << 8;
+    fAcc += ((int)msg[18]) << 16;
+    fAcc += ((int)msg[19]) << 24;
+    //uint32_t fAccuracy = fAcc;
+
+    // meaning of columns:
+    // 01 22 - signature of NAV-CLOCK message
+    // second in current week (s), clock bias (ns), clock drift (ns/s), time accuracy (ns), freq accuracy (ps/s)
+  //   cout<<"01 22 "<<dec<<iTOW/1000<<" "<<clkB<<" "<<clkD<<" "<<tAcc<<" "<<fAcc<<flush;
+  //   cout<<endl;
+
+
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX-NAV-CLOCK message:" << endl;
+        tempStream << " iTOW          : " << dec << iTOW / 1000 << " s" << endl;
+        tempStream << " clock bias    : " << dec << clkB << " ns" << endl;
+        tempStream << " clock drift   : " << dec << clkD << " ns/s" << endl;
+        tempStream << " time accuracy : " << dec << tAcc << " ns" << endl;
+        tempStream << " freq accuracy : " << dec << fAcc << " ps/s";
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+}
+
+
+void QtSerialUblox::UBXNavTimeGPS(const std::string& msg)
+{
+    // parse all fields
+    // GPS time of week
+    uint32_t iTOW = (int)msg[0];
+    iTOW += ((int)msg[1]) << 8;
+    iTOW += ((int)msg[2]) << 16;
+    iTOW += ((int)msg[3]) << 24;
+
+    int32_t fTOW = (int)msg[4];
+    fTOW += ((int)msg[5]) << 8;
+    fTOW += ((int)msg[6]) << 16;
+    fTOW += ((int)msg[7]) << 24;
+
+    //  int32_t ftow=iTOW/1000;
+
+    uint16_t wnR = (int)msg[8];
+    wnR += ((int)msg[9]) << 8;
+
+    int8_t leapS = (int)msg[10];
+    uint8_t flags = (int)msg[11];
+
+    // time accuracy estimate
+    uint32_t tAcc = (int)msg[12];
+    tAcc += ((int)msg[13]) << 8;
+    tAcc += ((int)msg[14]) << 16;
+    tAcc += ((int)msg[15]) << 24;
+    //uint32_t tAccuracy = tAcc;
+
+
+    double sr = iTOW / 1000.;
+    sr = sr - iTOW / 1000;
+
+    // meaning of columns:
+    // 01 20 - signature of NAV-TIMEGPS message
+    // week nr, second in current week, ns of timestamp in current second,
+    // nr of leap seconds wrt UTC, accuracy (ns)
+  //   cout<<"01 20 "<<dec<<wnR<<" "<<iTOW/1000<<" "<<(long int)(sr*1e9+fTOW)<<" "<<(int)leapS<<" "<<tAcc<<flush;
+  //   cout<<endl;
+
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX-NAV-TIMEGPS message:" << endl;
+        tempStream << " week nr       : " << dec << wnR << endl;
+        tempStream << " iTOW          : " << dec << iTOW << " ms = " << iTOW / 1000 << " s" << endl;
+        tempStream << " fTOW          : " << dec << fTOW << " = " << (long int)(sr*1e9 + fTOW) << " ns" << endl;
+        tempStream << " leap seconds  : " << dec << (int)leapS << " s" << endl;
+        tempStream << " time accuracy : " << dec << tAcc << " ns" << endl;
+        tempStream << " flags             : ";
+        for (int i = 7; i >= 0; i--) if (flags & 1 << i) tempStream << i; else tempStream << "-";
+        tempStream << endl;
+        tempStream << "   tow valid        : " << string((flags & 1) ? "yes" : "no") << endl;
+        tempStream << "   week valid       : " << string((flags & 2) ? "yes" : "no") << endl;
+        tempStream << "   leap sec valid   : " << string((flags & 4) ? "yes" : "no");
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+    //mutex.lock();
+    emit gpsPropertyUpdatedUint32(tAcc, timeAccuracy.updateAge(), 'a');
+    timeAccuracy = tAcc;
+    timeAccuracy.lastUpdate = std::chrono::system_clock::now();
+    if (flags & 4) { leapSeconds = leapS; }
+    //mutex.unlock();
+
+    struct timespec ts = unixtime_from_gps(wnR, iTOW / 1000, (long int)(sr*1e9 + fTOW)/*, this->leapSeconds()*/);
+    std::stringstream tempStream;
+    //std::string temp;
+    tempStream << ts.tv_sec << '.' << ts.tv_nsec;
+    //tempStream >> temp;
+    emit toConsole(QString::fromStdString(tempStream.str()));
+}
+
+void QtSerialUblox::UBXNavTimeUTC(const std::string& msg)
+{
+    // parse all fields
+    // GPS time of week
+    uint32_t iTOW = (int)msg[0];
+    iTOW += ((int)msg[1]) << 8;
+    iTOW += ((int)msg[2]) << 16;
+    iTOW += ((int)msg[3]) << 24;
+
+    // time accuracy estimate
+    uint32_t tAcc = (int)msg[4];
+    tAcc += ((int)msg[5]) << 8;
+    tAcc += ((int)msg[6]) << 16;
+    tAcc += ((int)msg[7]) << 24;
+    //uint32_t tAccuracy = tAcc;
+    //mutex.lock();
+    emit gpsPropertyUpdatedUint32(tAcc, timeAccuracy.updateAge(), 'a');
+    timeAccuracy = tAcc;
+    timeAccuracy.lastUpdate = std::chrono::system_clock::now();
+    //mutex.unlock();
+
+    int32_t nano = (int)msg[8];
+    nano += ((int)msg[9]) << 8;
+    nano += ((int)msg[10]) << 16;
+    nano += ((int)msg[11]) << 24;
+
+    uint16_t year = (int)msg[12];
+    year += ((int)msg[13]) << 8;
+
+    uint16_t month = (int)msg[14];
+    uint16_t day = (int)msg[15];
+    uint16_t hour = (int)msg[16];
+    uint16_t min = (int)msg[17];
+    uint16_t sec = (int)msg[18];
+
+    uint8_t flags = (int)msg[19];
+
+    double sr = iTOW / 1000.;
+    sr = sr - iTOW / 1000;
+
+    // meaning of columns:
+    // 01 21 - signature of NAV-TIMEUTC message
+    // second in current week, year, month, day, hour, minute, seconds(+fraction)
+    // accuracy (ns)
+  //   cout<<"01 21 "<<dec<<iTOW/1000<<" "<<year<<" "<<month<<" "<<day<<" "<<hour<<" "<<min<<" "<<(double)(sec+nano*1e-9)<<" "<<tAcc<<flush;
+  //   cout<<endl;
+
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX-NAV-TIMEUTC message:" << endl;
+        tempStream << " iTOW           : " << dec << iTOW << " ms = " << iTOW / 1000 << " s" << endl;
+        tempStream << " nano           : " << dec << nano << " ns" << endl;
+        tempStream << " date y/m/d     : " << dec << (int)year << "/" << (int)month << "/" << (int)day << endl;
+        tempStream << " UTC time h:m:s : " << dec << setw(2) << setfill('0') << hour << ":" << (int)min << ":" << (double)(sec + nano * 1e-9) << endl;
+        tempStream << " time accuracy : " << dec << tAcc << " ns" << endl;
+        tempStream << " flags             : ";
+        for (int i = 7; i >= 0; i--) if (flags & 1 << i) tempStream << i; else tempStream << "-";
+        tempStream << endl;
+        tempStream << "   tow valid        : " << string((flags & 1) ? "yes" : "no") << endl;
+        tempStream << "   week valid       : " << string((flags & 2) ? "yes" : "no") << endl;
+        tempStream << "   UTC time valid   : " << string((flags & 4) ? "yes" : "no") << endl;
+        string utcStd;
+        switch ((flags & 0xf0) >> 4) {
+        case 0:
+            utcStd = "n/a";
+            break;
+        case 1:
+            utcStd = "CRL";
+            break;
+        case 2:
+            utcStd = "NIST";
+            break;
+        case 3:
+            utcStd = "USNO";
+            break;
+        case 4:
+            utcStd = "BIPM";
+            break;
+        case 5:
+            utcStd = "EU";
+            break;
+        case 6:
+            utcStd = "SU";
+            break;
+        case 7:
+            utcStd = "NTSC";
+            break;
+        default:
+            utcStd = "unknown";
+        }
+        tempStream << "   UTC standard  : " << utcStd;
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+}
+
+void QtSerialUblox::UBXMonHW(const std::string& msg)
+{
+    // parse all fields
+    // noise
+    uint16_t noisePerMS = (int)msg[16];
+    noisePerMS += ((int)msg[17]) << 8;
+    noise = noisePerMS;
+
+    // agc
+    uint16_t agcCnt = (int)msg[18];
+    agcCnt += ((int)msg[19]) << 8;
+    agc = agcCnt;
+
+    uint8_t flags = (int)msg[22];
+
+    // meaning of columns:
+    // 01 21 - signature of NAV-TIMEUTC message
+    // second in current week, year, month, day, hour, minute, seconds(+fraction)
+    // accuracy (ns)
+  //   cout<<"0a 09 "<<dec<<noisePerMS<<" "<<agcCnt<<" "<<flush;
+  //   cout<<endl;
+
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << "*** UBX-MON-HW message:" << endl;
+        tempStream << " noise            : " << dec << noisePerMS << " dBc" << endl;
+        tempStream << " agcCnt (0..8192) : " << dec << agcCnt << endl;
+        tempStream << " flags             : ";
+        for (int i = 7; i >= 0; i--) if (flags & 1 << i) tempStream << i; else tempStream << "-";
+        tempStream << endl;
+        tempStream << "   RTC calibrated   : " << string((flags & 1) ? "yes" : "no") << endl;
+        tempStream << "   safe boot        : " << string((flags & 2) ? "yes" : "no") << endl;
+        tempStream << "   jamming state    : " << (int)((flags & 0x0c) >> 2) << endl;
+        tempStream << "   Xtal absent      : " << string((flags & 0x10) ? "yes" : "no");
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+}
+
+
+void QtSerialUblox::UBXMonTx(const std::string& msg)
+{
+    // parse all fields
+    // nr bytes pending
+    uint16_t pending[6];
+    uint8_t usage[6];
+    uint8_t peakUsage[6];
+    uint8_t tUsage;
+    uint8_t tPeakUsage;
+    //uint8_t errors;
+
+    for (int i = 0; i < 6; i++) {
+        pending[i] = msg[2 * i];
+        pending[i] |= (uint16_t)msg[2 * i + 1] << 8;
+        usage[i] = msg[i + 12];
+        peakUsage[i] = msg[i + 18];
+    }
+
+    tUsage = msg[24];
+    tPeakUsage = msg[25];
+    //errors = msg[26];
+
+    // meaning of columns:
+    // 01 21 - signature of NAV-TIMEUTC message
+    // second in current week, year, month, day, hour, minute, seconds(+fraction)
+    // accuracy (ns)
+  //   cout<<"0a 09 "<<dec<<noisePerMS<<" "<<agcCnt<<" "<<flush;
+  //   cout<<endl;
+    //mutex.lock();
+    emit gpsPropertyUpdatedUint8(tUsage,txBufUsage.updateAge(),'b');
+    emit gpsPropertyUpdatedUint8(tPeakUsage, txBufPeakUsage.updateAge(), 'p');
+    txBufUsage = tUsage;
+    txBufPeakUsage = tPeakUsage;
+    //mutex.unlock();
+
+    if (verbose > 1) {
+        std::stringstream tempStream;
+        //std::string temp;
+        tempStream << setfill(' ') << setw(3);
+        tempStream << "*** UBX-MON-TXBUF message:" << endl;
+        tempStream << " global TX buf usage      : " << dec << (int)tUsage << " %" << endl;
+        tempStream << " global TX buf peak usage : " << dec << (int)tPeakUsage << " %" << endl;
+        tempStream << " TX buf usage for target      : ";
+        for (int i = 0; i < 6; i++) {
+            tempStream << "    (" << dec << i << ") " << setw(3) << (int)usage[i];
+        }
+        tempStream << endl;
+        tempStream << " TX buf peak usage for target : ";
+        for (int i = 0; i < 6; i++) {
+            tempStream << "    (" << dec << i << ") " << setw(3) << (int)peakUsage[i];
+        }
+        tempStream << endl;
+        tempStream << " TX bytes pending for target  : ";
+        for (int i = 0; i < 6; i++) {
+            tempStream << "    (" << dec << i << ") " << setw(3) << pending[i];
+        }
+        tempStream << setw(1) << setfill(' ');
+        //tempStream >> temp;
+        emit toConsole(QString::fromStdString(tempStream.str()));
+    }
+}

--- a/myon_detector/serial.cpp
+++ b/myon_detector/serial.cpp
@@ -22,7 +22,7 @@ using namespace std;
 		std::cerr<<"unable to open port "<<portname<<std::endl;
   }
   else
-    fcntl(fd, F_SETFL, 0);
+	fcntl(fd, F_SETFL, 0);
   //return (fd);
 }
  */
@@ -40,22 +40,22 @@ Serial::Serial() {
 	fBufIndex = 0;
 	fBlocking = false;
 	fVerbose = VERBOSITY;
-   fd=-1;
+	fd = -1;
 }
 
-Serial::Serial(	const std::string& portname,
-		 				int baud,
-						unsigned char nrDataBits,
-						unsigned char nrStopBits,
-						int bufferSize,
-						PARITY parity,
-						bool blocking)
+Serial::Serial(const std::string& portname,
+	int baud,
+	unsigned char nrDataBits,
+	unsigned char nrStopBits,
+	int bufferSize,
+	PARITY parity,
+	bool blocking)
 	: fPortName(portname), fBaud(baud), fDataBits(nrDataBits), fStopBits(nrStopBits), fBufSize(bufferSize), fParity(parity), fBlocking(blocking)
 {
 	fVerbose = VERBOSITY;
-   fd=-1;
-   fTimeout = 1; // timeout in tenths of seconds
-   //fBufSize = 1000;
+	fd = -1;
+	fTimeout = 1; // timeout in tenths of seconds
+	//fBufSize = 1000;
 }
 
 
@@ -66,49 +66,52 @@ Serial::~Serial() {
 }
 
 int Serial::initPort(int baud,
-                     unsigned char nrDataBits,
-                     unsigned char nrStopBits,
-                     int bufferSize,
-                     PARITY parity,
-                     bool blocking)
+	unsigned char nrDataBits,
+	unsigned char nrStopBits,
+	int bufferSize,
+	PARITY parity,
+	bool blocking)
 {
-   fBaud = baud;
-   fDataBits = nrDataBits;
-   fStopBits = nrStopBits;
-   fParity = parity;
-   fBufSize = bufferSize;
-   fBufIndex = 0;
-   fBlocking = blocking;
+	fBaud = baud;
+	fDataBits = nrDataBits;
+	fStopBits = nrStopBits;
+	fParity = parity;
+	fBufSize = bufferSize;
+	fBufIndex = 0;
+	fBlocking = blocking;
 
-   if (fd!=-1) closePort();
-   initPort();
+	if (fd != -1) closePort();
+	return initPort();
 }
 
 int Serial::initPort() {
 
 	// Try to open serial port with r/w access
 	if (fVerbose > 0)
-		std::cout<<"SERIAL: Opening "<<fPortName<<" at "<<fBaud<<" baud...";
+		std::cout << "SERIAL: Opening " << fPortName << " at " << fBaud << " baud...";
 
 	if (fBlocking)
-//	  fd = ::open(fPortName.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
- 	  fd = ::open(fPortName.c_str(), O_RDWR);
-	else 
-	  fd = ::open(fPortName.c_str(), O_RDWR | O_NONBLOCK);
+		//	  fd = ::open(fPortName.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
+		fd = ::open(fPortName.c_str(), O_RDWR);
+	else
+		fd = ::open(fPortName.c_str(), O_RDWR | O_NONBLOCK);
 
-   // As long as port is actually open...
-	if(fd != -1) {
+	// As long as port is actually open...
+	if (fd != -1) {
 
 		// Share the good news
 		if (fVerbose > 0)
 		{
-			std::cout<<"OK"<<std::endl;
+			std::cout << "OK" << std::endl;
 			// Display blocking info
-			if (fBlocking)
-			if (fVerbose > 0)
-			  std::cout<<"SERIAL: Blocking enabled"<<std::endl;
-			else if (fVerbose > 0)
-			  std::cout<<"SERIAL: Blocking disabled"<<std::endl;
+			if (fBlocking) {
+				if (fVerbose > 0) {
+					std::cout << "SERIAL: Blocking enabled" << std::endl;
+				}
+			}
+			else if (fVerbose > 0) {
+				std::cout << "SERIAL: Blocking disabled" << std::endl;
+			}
 		}
 
 		// Configure port settings
@@ -121,123 +124,123 @@ int Serial::initPort() {
 		// Convert integer baud to Baud type
 		// Default to 9600 baud if none specified
 		switch (fBaud) {
-			case 50:
-				cfsetispeed(&options, B50);
-				cfsetospeed(&options, B50);
-				break;
-			case 75:
-				cfsetispeed(&options, B75);
-				cfsetospeed(&options, B75);
-				break;
-			case 110:
-				cfsetispeed(&options, B110);
-				cfsetospeed(&options, B110);
-				break;
-			case 134:
-				cfsetispeed(&options, B134);
-				cfsetospeed(&options, B134);
-				break;
-			case 150:
-				cfsetispeed(&options, B150);
-				cfsetospeed(&options, B150);
-				break;
-			case 200:
-				cfsetispeed(&options, B200);
-				cfsetospeed(&options, B200);
-				break;
-			case 300:
-				cfsetispeed(&options, B300);
-				cfsetospeed(&options, B300);
-				break;
-			case 600:
-				cfsetispeed(&options, B600);
-				cfsetospeed(&options, B600);
-				break;
-			case 1200:
-				cfsetispeed(&options, B1200);
-				cfsetospeed(&options, B1200);
-				break;
-			case 1800:
-				cfsetispeed(&options, B1800);
-				cfsetospeed(&options, B1800);
-				break;
-			case 2400:
-				cfsetispeed(&options, B2400);
-				cfsetospeed(&options, B2400);
-				break;
-			case 4800:
-				cfsetispeed(&options, B4800);
-				cfsetospeed(&options, B4800);
-				break;
-			case 9600:
-			default:
-				cfsetispeed(&options, B9600);
-				cfsetospeed(&options, B9600);
-				break;
-			case 38400:
-				cfsetispeed(&options, B38400);
-				cfsetospeed(&options, B38400);
-				break;
-			case 57600:
-				cfsetispeed(&options, B57600);
-				cfsetospeed(&options, B57600);
-				break;
-			case 115200:
-				cfsetispeed(&options, B115200);
-				cfsetospeed(&options, B115200);
-				break;
-			case 230400:
-				cfsetispeed(&options, B230400);
-				cfsetospeed(&options, B230400);
-				break;
-			case 460800:
-				cfsetispeed(&options, B460800);
-				cfsetospeed(&options, B460800);
-				break;
-			case 500000:
-				cfsetispeed(&options, B500000);
-				cfsetospeed(&options, B500000);
-				break;
-			case 576000:
-				cfsetispeed(&options, B576000);
-				cfsetospeed(&options, B576000);
-				break;
-			case 921600:
-				cfsetispeed(&options, B921600);
-				cfsetospeed(&options, B921600);
-				break;
-			case 1000000:
-				cfsetispeed(&options, B1000000);
-				cfsetospeed(&options, B1000000);
-				break;
-			case 1152000:
-				cfsetispeed(&options, B1152000);
-				cfsetospeed(&options, B1152000);
-				break;
-			case 1500000:
-				cfsetispeed(&options, B1500000);
-				cfsetospeed(&options, B1500000);
-				break;
-			case 2000000:
-				cfsetispeed(&options, B2000000);
-				cfsetospeed(&options, B2000000);
-				break;
-			case 2500000:
-				cfsetispeed(&options, B2500000);
-				cfsetospeed(&options, B2500000);
-				break;
-			case 3000000:
-				cfsetispeed(&options, B3000000);
-				cfsetospeed(&options, B3000000);
-				break;
-			case 3500000:
-				cfsetispeed(&options, B3500000);
-				cfsetospeed(&options, B3500000);
-				break;
-			case 4000000:
-				cfsetispeed(&options, B4000000);
-				cfsetospeed(&options, B4000000);
-				break;
+		case 50:
+			cfsetispeed(&options, B50);
+			cfsetospeed(&options, B50);
+			break;
+		case 75:
+			cfsetispeed(&options, B75);
+			cfsetospeed(&options, B75);
+			break;
+		case 110:
+			cfsetispeed(&options, B110);
+			cfsetospeed(&options, B110);
+			break;
+		case 134:
+			cfsetispeed(&options, B134);
+			cfsetospeed(&options, B134);
+			break;
+		case 150:
+			cfsetispeed(&options, B150);
+			cfsetospeed(&options, B150);
+			break;
+		case 200:
+			cfsetispeed(&options, B200);
+			cfsetospeed(&options, B200);
+			break;
+		case 300:
+			cfsetispeed(&options, B300);
+			cfsetospeed(&options, B300);
+			break;
+		case 600:
+			cfsetispeed(&options, B600);
+			cfsetospeed(&options, B600);
+			break;
+		case 1200:
+			cfsetispeed(&options, B1200);
+			cfsetospeed(&options, B1200);
+			break;
+		case 1800:
+			cfsetispeed(&options, B1800);
+			cfsetospeed(&options, B1800);
+			break;
+		case 2400:
+			cfsetispeed(&options, B2400);
+			cfsetospeed(&options, B2400);
+			break;
+		case 4800:
+			cfsetispeed(&options, B4800);
+			cfsetospeed(&options, B4800);
+			break;
+		case 9600:
+		default:
+			cfsetispeed(&options, B9600);
+			cfsetospeed(&options, B9600);
+			break;
+		case 38400:
+			cfsetispeed(&options, B38400);
+			cfsetospeed(&options, B38400);
+			break;
+		case 57600:
+			cfsetispeed(&options, B57600);
+			cfsetospeed(&options, B57600);
+			break;
+		case 115200:
+			cfsetispeed(&options, B115200);
+			cfsetospeed(&options, B115200);
+			break;
+		case 230400:
+			cfsetispeed(&options, B230400);
+			cfsetospeed(&options, B230400);
+			break;
+		case 460800:
+			cfsetispeed(&options, B460800);
+			cfsetospeed(&options, B460800);
+			break;
+		case 500000:
+			cfsetispeed(&options, B500000);
+			cfsetospeed(&options, B500000);
+			break;
+		case 576000:
+			cfsetispeed(&options, B576000);
+			cfsetospeed(&options, B576000);
+			break;
+		case 921600:
+			cfsetispeed(&options, B921600);
+			cfsetospeed(&options, B921600);
+			break;
+		case 1000000:
+			cfsetispeed(&options, B1000000);
+			cfsetospeed(&options, B1000000);
+			break;
+		case 1152000:
+			cfsetispeed(&options, B1152000);
+			cfsetospeed(&options, B1152000);
+			break;
+		case 1500000:
+			cfsetispeed(&options, B1500000);
+			cfsetospeed(&options, B1500000);
+			break;
+		case 2000000:
+			cfsetispeed(&options, B2000000);
+			cfsetospeed(&options, B2000000);
+			break;
+		case 2500000:
+			cfsetispeed(&options, B2500000);
+			cfsetospeed(&options, B2500000);
+			break;
+		case 3000000:
+			cfsetispeed(&options, B3000000);
+			cfsetospeed(&options, B3000000);
+			break;
+		case 3500000:
+			cfsetispeed(&options, B3500000);
+			cfsetospeed(&options, B3500000);
+			break;
+		case 4000000:
+			cfsetispeed(&options, B4000000);
+			cfsetospeed(&options, B4000000);
+			break;
 		}
 
 		// Set options for proper port settings
@@ -245,50 +248,50 @@ int Serial::initPort() {
 		options.c_cflag |= (CLOCAL | CREAD);
 
 		switch (fParity) {
-			case ODD:
-				options.c_cflag |= PARENB;
-				options.c_cflag |= PARODD;
-//				printf("SERIAL: parity set to ODD\n");
-				break;
-			case EVEN:
-				options.c_cflag |= PARENB;
-				options.c_cflag &= ~PARODD;
-//				printf("SERIAL: parity set to EVEN\n");
-				break;
-			default:
-				// No parity
-				options.c_cflag &= ~PARENB;
-//				options.c_cflag |= CS8;
-//				printf("SERIAL: No parity set\n");
-				break;
+		case ODD:
+			options.c_cflag |= PARENB;
+			options.c_cflag |= PARODD;
+			//				printf("SERIAL: parity set to ODD\n");
+			break;
+		case EVEN:
+			options.c_cflag |= PARENB;
+			options.c_cflag &= ~PARODD;
+			//				printf("SERIAL: parity set to EVEN\n");
+			break;
+		default:
+			// No parity
+			options.c_cflag &= ~PARENB;
+			//				options.c_cflag |= CS8;
+			//				printf("SERIAL: No parity set\n");
+			break;
 		}
 
-      switch (fDataBits)
-      {
-         case 8:
-         default:
-            options.c_cflag |= CS8;
-            break;
-         case 7:
-            options.c_cflag |= CS7;
-            break;
-         case 6:
-            options.c_cflag |= CS6;
-            break;
-         case 5:
-            options.c_cflag |= CS5;
-            break;
-      }  //end of switch data_bits
+		switch (fDataBits)
+		{
+		case 8:
+		default:
+			options.c_cflag |= CS8;
+			break;
+		case 7:
+			options.c_cflag |= CS7;
+			break;
+		case 6:
+			options.c_cflag |= CS6;
+			break;
+		case 5:
+			options.c_cflag |= CS5;
+			break;
+		}  //end of switch data_bits
 
-      switch (fStopBits)
-      {
-         case 1:
-         default:
-            break;
-         case 2:
-            options.c_cflag |= CSTOPB;
-            break;
-      }
+		switch (fStopBits)
+		{
+		case 1:
+		default:
+			break;
+		case 2:
+			options.c_cflag |= CSTOPB;
+			break;
+		}
 
 
 		// Turn off hardware flow control
@@ -297,8 +300,8 @@ int Serial::initPort() {
 		options.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG);
 		options.c_lflag |= ICANON;
 		// Write our changes to the port configuration
-      options.c_cc[VTIME]    = fTimeout;   /* inter-character timer */
-      options.c_cc[VMIN]     = 1;   /* blocking read until n chars received */
+		options.c_cc[VTIME] = fTimeout;   /* inter-character timer */
+		options.c_cc[VMIN] = 1;   /* blocking read until n chars received */
 		tcsetattr(fd, TCSANOW, &options);
 	}
 
@@ -315,7 +318,7 @@ int Serial::initPort() {
 }
 
 bool Serial::open() {
-   return (initPort()!=-1);
+	return (initPort() != -1);
 }
 
 void Serial::flushPort() {
@@ -326,27 +329,27 @@ void Serial::flushPort() {
 
 void Serial::setTimeout(int timeout)
 {
-   fTimeout=timeout;
-   return;
-   struct termios options;
-   tcgetattr(fd, &options);
-   options.c_cc[VTIME]    = timeout;   /* inter-character timer */
-   options.c_cc[VMIN]     = 1;   /* blocking read until n chars received */
-   tcflush(fd, TCIFLUSH);
-   tcsetattr(fd,TCSANOW,&options);
+	fTimeout = timeout;
+	return;
+	struct termios options;
+	tcgetattr(fd, &options);
+	options.c_cc[VTIME] = timeout;   /* inter-character timer */
+	options.c_cc[VMIN] = 1;   /* blocking read until n chars received */
+	tcflush(fd, TCIFLUSH);
+	tcsetattr(fd, TCSANOW, &options);
 }
 
 
 int Serial::getData(std::string& data, int nrBytes) {
 
-   struct termios options;
-   tcgetattr(fd, &options);
-   options.c_cc[VTIME]    = fTimeout;   /* inter-character timer */
-//    options.c_cc[VTIME]    = 1;   /* inter-character timer */
-//    options.c_cc[VMIN]     = 200;   /* blocking read until n chars received */
-   options.c_cc[VMIN]     = nrBytes;   /* blocking read until n chars received */
-//     tcflush(fd, TCIFLUSH);
-   tcsetattr(fd,TCSANOW,&options);
+	struct termios options;
+	tcgetattr(fd, &options);
+	options.c_cc[VTIME] = fTimeout;   /* inter-character timer */
+ //    options.c_cc[VTIME]    = 1;   /* inter-character timer */
+ //    options.c_cc[VMIN]     = 200;   /* blocking read until n chars received */
+	options.c_cc[VMIN] = nrBytes;   /* blocking read until n chars received */
+ //     tcflush(fd, TCIFLUSH);
+	tcsetattr(fd, TCSANOW, &options);
 
 	// If the port is actually open, read the data
 	data.clear();
@@ -356,13 +359,13 @@ int Serial::getData(std::string& data, int nrBytes) {
 //		return read(fd, data, sizeof(data));
 		char buf[nrBytes];
 		result = ::read(fd, buf, nrBytes);
-		if (result<0) {
-// 		  cerr<<"error reading from serial port"<<endl;
-		  return 0;
+		if (result < 0) {
+			// 		  cerr<<"error reading from serial port"<<endl;
+			return 0;
 		}
 		if (result > 0) {
 			data.resize(result);
-			for (int i=0; i<result; i++) data[i]=buf[i];
+			for (int i = 0; i < result; i++) data[i] = buf[i];
 		}
 	}
 	// Port is closed!
@@ -371,13 +374,13 @@ int Serial::getData(std::string& data, int nrBytes) {
 
 int Serial::read(std::string& data, int nrBytes)
 {
-   return getData(data, nrBytes);
+	return getData(data, nrBytes);
 }
 
 int Serial::read(std::string& data, int nrBytes, int timeout)
 {
-   fTimeout=timeout;
-   return getData(data, nrBytes);
+	fTimeout = timeout;
+	return getData(data, nrBytes);
 }
 
 
@@ -394,61 +397,63 @@ int Serial::sendData(const std::string& data) {
 }
 
 int Serial::write(const std::string& data) {
-   return sendData(data);
+	return sendData(data);
 }
 
 int Serial::readLine(std::string& data, char delim)
 {
-/*
-   struct termios options;
-   tcgetattr(fd, &options);
-   options.c_cc[VTIME]    = fTimeout;   // inter-character timer
-   options.c_cc[VMIN]     = 0;   // blocking read until n chars received
-   tcflush(fd, TCIFLUSH);
-   tcsetattr(fd,TCSANOW,&options);
-*/
-   data.clear();
-   // If the port is actually open, grab a byte
-   if (fd != -1) {
-    while (true) {
-      // Return the byte received if it's there
-      int n = -1;
-      int delay = 0;
-      while (n < 1) {
-         n = ::read(fd, &temp[0], 1);
-         if (n == -1) usleep(100);   // wait 100us
-         delay++;
-         if (delay > fTimeout*1000) {
-	    cerr<<"Timeout"<<endl;
-	    return data.size();
-	 }
-      }
-      //cout<<"delay="<<delay<<endl;
-      if (n > 0) {
-            //cout<<"n="<<n<<endl;
-            for (int i = 0; i < n ; i++) {
-//               data.push_back(temp[i]);
-	       //cout<<" "<<temp[i];
-               if (temp[i]==delim) {
-		  //cout<<"delim found"<<endl;
-		  return data.size();
-	       }
-               data.push_back(temp[i]);
-            }
-      }
+	/*
+	   struct termios options;
+	   tcgetattr(fd, &options);
+	   options.c_cc[VTIME]    = fTimeout;   // inter-character timer
+	   options.c_cc[VMIN]     = 0;   // blocking read until n chars received
+	   tcflush(fd, TCIFLUSH);
+	   tcsetattr(fd,TCSANOW,&options);
+	*/
+	data.clear();
+	// If the port is actually open, grab a byte
+	if (fd != -1) {
+		while (true) {
+			// Return the byte received if it's there
+			int n = -1;
+			int delay = 0;
+			while (n < 1) {
+				n = ::read(fd, &temp[0], 1);
+				if (n == -1) usleep(100);   // wait 100us
+				delay++;
+				if (delay > fTimeout * 1000) {
+					cerr << "Timeout" << endl;
+					return data.size();
+				}
+			}
+			//cout<<"delay="<<delay<<endl;
+			if (n > 0) {
+				//cout<<"n="<<n<<endl;
+				for (int i = 0; i < n; i++) {
+					//               data.push_back(temp[i]);
+							   //cout<<" "<<temp[i];
+					if (temp[i] == delim) {
+						//cout<<"delim found"<<endl;
+						return data.size();
+					}
+					data.push_back(temp[i]);
+				}
+			}
+		}
     }
-   }
+    // should only get here if fd is -1
+    return -1;
 }
 
 bool Serial::isDataAvailable(char& data)
 {
 
-   struct termios options;
-   tcgetattr(fd, &options);
-   options.c_cc[VTIME]    = 0;   // inter-character timer
-   options.c_cc[VMIN]     = 1;   // blocking read until n chars received
-   tcflush(fd, TCIFLUSH);
-   tcsetattr(fd,TCSANOW,&options);
+	struct termios options;
+	tcgetattr(fd, &options);
+	options.c_cc[VTIME] = 0;   // inter-character timer
+	options.c_cc[VMIN] = 1;   // blocking read until n chars received
+	tcflush(fd, TCIFLUSH);
+	tcsetattr(fd, TCSANOW, &options);
 
 	int result = -1;
 	if (fd != -1) {
@@ -457,8 +462,8 @@ bool Serial::isDataAvailable(char& data)
 		char buf[100];
 		result = ::read(fd, buf, 1);
 		if (result > 0) {
-		   data=buf[0];
-		   return true;
+			data = buf[0];
+			return true;
 		}
 
 	}
@@ -468,125 +473,115 @@ bool Serial::isDataAvailable(char& data)
 }
 
 char Serial::getChar(int timeout_ms) {
-/*
-   struct termios options;
-   tcgetattr(fd, &options);
-   options.c_cc[VTIME]    = 0;   // inter-character timer
-   options.c_cc[VMIN]     = 1;   // blocking read until n chars received
-   tcflush(fd, TCIFLUSH);
-   tcsetattr(fd,TCSANOW,&options);
-*/
+	/*
+	   struct termios options;
+	   tcgetattr(fd, &options);
+	   options.c_cc[VTIME]    = 0;   // inter-character timer
+	   options.c_cc[VMIN]     = 1;   // blocking read until n chars received
+	   tcflush(fd, TCIFLUSH);
+	   tcsetattr(fd,TCSANOW,&options);
+	*/
 	int delay = 0;
-	switch (fBlocking) {
+	if (!fBlocking) {
 		// Non-blocking mode enable, so use the buffer
-		case false:
-			if (fBufIndex > 0) {
-				// Yes, so grab the byte we need and shift the buffer left
-				char c = fBuf[1];
-				for (int j = 1; j < (fBufIndex + 1); j++) {
-					fBuf[j] = fBuf[j + 1];
-				}
-				fBufIndex--;
-				// Send back the first byte in the buffer
-				return c;
+		if (fBufIndex > 0) {
+			// Yes, so grab the byte we need and shift the buffer left
+			char c = fBuf[1];
+			for (int j = 1; j < (fBufIndex + 1); j++) {
+				fBuf[j] = fBuf[j + 1];
 			}
-			// If the port is actually open, grab a byte
-			if (fd != -1) {
-				// Return the byte received if it's there
-				int n = ::read(fd, &temp[0], 1);
-				if (n > -1) {
-					// Just 1 byte, so return it right away
-					if (n == 1) return temp[0];
-					// More than 1 byte there, so buffer them and return the first
-					else {
-						for (int i = 0; i < (n - 1); i++) {
-							fBufIndex++;
-							fBuf[fBufIndex] = temp[i + 1];
-						}
-						return temp[0];
+			fBufIndex--;
+			// Send back the first byte in the buffer
+			return c;
+		}
+		// If the port is actually open, grab a byte
+		if (fd != -1) {
+			// Return the byte received if it's there
+			int n = ::read(fd, &temp[0], 1);
+			if (n > -1) {
+				// Just 1 byte, so return it right away
+				if (n == 1) return temp[0];
+				// More than 1 byte there, so buffer them and return the first
+				else {
+					for (int i = 0; i < (n - 1); i++) {
+						fBufIndex++;
+						fBuf[fBufIndex] = temp[i + 1];
 					}
+					return temp[0];
 				}
-				else return -1;
 			}
-			break;
-		// Blocking mode enabled, so wait until we get a byte
-		case true:
-			if (fBufIndex > 0) {
-				// Yes, so grab the byte we need and shift the buffer left
-				char c = fBuf[1];
-				for (int j = 1; j < (fBufIndex + 1); j++) {
-					fBuf[j] = fBuf[j + 1];
-				}
-				fBufIndex--;
-				// Send back the first byte in the buffer
-				return c;
-			}
-			// If the port is actually open, grab a byte
-			if (fd != -1) {
-				// Return the byte received if it's there
-				int n = -1;
-				delay=0;
-				while (n < 1) {
-					n = ::read(fd, &temp[0], 1);
-					if (n == -1) usleep(100);	// wait 1ms
-					delay++;
-					if (delay > timeout_ms*10) return -1;
-				}
-				if (n > -1) {
-					// Just 1 byte, so return it right away
-					if (n == 1) return temp[0];
-					// More than 1 byte there, so buffer them and return the first
-					else {
-						for (int i = 0; i < (n - 1); i++) {
-							fBufIndex++;
-							fBuf[fBufIndex] = temp[i + 1];
-						}
-						return temp[0];
-					}
-				}
-				else return -1;
-			}
-			// Port is closed!
 			else return -1;
-			break;
+		}
+		// Blocking mode enabled, so wait until we get a byte
+	}
+	else {
+		if (fBufIndex > 0) {
+			// Yes, so grab the byte we need and shift the buffer left
+			char c = fBuf[1];
+			for (int j = 1; j < (fBufIndex + 1); j++) {
+				fBuf[j] = fBuf[j + 1];
+			}
+			fBufIndex--;
+			// Send back the first byte in the buffer
+			return c;
+		}
+		// If the port is actually open, grab a byte
+		if (fd != -1) {
+			// Return the byte received if it's there
+			int n = -1;
+			delay = 0;
+			while (n < 1) {
+				n = ::read(fd, &temp[0], 1);
+				if (n == -1) usleep(100);	// wait 1ms
+				delay++;
+				if (delay > timeout_ms * 10) return -1;
+			}
+			if (n > -1) {
+				// Just 1 byte, so return it right away
+				if (n == 1) return temp[0];
+				// More than 1 byte there, so buffer them and return the first
+				else {
+					for (int i = 0; i < (n - 1); i++) {
+						fBufIndex++;
+						fBuf[fBufIndex] = temp[i + 1];
+					}
+					return temp[0];
+				}
+			}
+			else return -1;
+		}
+		// Port is closed!
+		else return -1;
 		// Blocking variable is messed up
-		default:
-         cerr<<"SERIAL: Error with blocking setting!"<<endl;
-			return -1;
-			break;
 	}
 	// Should never get here
 	return -1;
 }
 
 int Serial::sendChar(char data) {
-	switch (fBlocking) {
+	if (!fBlocking) {
 		// Non-blocking mode
-		case false:
 			// If the port is actually open, send a byte
-			if (fd != -1) {
-				// Send the data and return number of bytes actually written
-				::write(fd, &data, 1);
-				return 1;
-			}
-			else return -1;
-			break;
+		if (fd != -1) {
+			// Send the data and return number of bytes actually written
+			::write(fd, &data, 1);
+			return 1;
+		}
+		else return -1;
 		// Blocking mode
-		case true:
-			// If the port is actually open, send a byte
-			if (fd != -1) {
-				// Send the data and return number of bytes actually written
-				::write(fd, &data, 1);
-				return 1;
-			}
-			else return -1;
-			break;
-		// Blocking variable is messed up
-		default:
-			cerr<<"SERIAL: Error with blocking setting!"<<endl;
-			return -1;
-			break;
 	}
+	else {
+		// If the port is actually open, send a byte
+		if (fd != -1) {
+			// Send the data and return number of bytes actually written
+			::write(fd, &data, 1);
+			return 1;
+		}
+		else return -1;
+		// Blocking variable is messed up
+	}
+	// should never get here
+	return -1;
 }
 
 void Serial::closePort() {
@@ -594,9 +589,9 @@ void Serial::closePort() {
 	// If the port is actually open, close it
 	if (fd != -1) {
 		close(fd);
-      fd=-1;
+		fd = -1;
 		if (fVerbose > 0)
-			std::cout<<"SERIAL: Device "<<fPortName<<" is now closed."<<std::endl;
+			std::cout << "SERIAL: Device " << fPortName << " is now closed." << std::endl;
 	}
 }
 

--- a/myon_detector/structs_and_defines.h
+++ b/myon_detector/structs_and_defines.h
@@ -104,6 +104,9 @@
 #define MSG_NMEA_SVSTATUS 0xf103
 #define MSG_NMEA_TIME 0xf104
 
+#define PROTO_UBX 1
+#define PROTO_NMEA 0b10
+#define PROTO_RTCM3 0b100000
 
 #include <string>
 #include <chrono>

--- a/myon_detector/structs_and_defines.h
+++ b/myon_detector/structs_and_defines.h
@@ -1,6 +1,8 @@
 #ifndef STRUCTS_AND_DEFINES_H
 #define STRUCTS_AND_DEFINES__H
 
+
+// list of UBX message Cls/ID
 #define MSG_ACK			0x0501
 #define MSG_NAK			0x0500
 
@@ -76,6 +78,32 @@
 #define MSG_MON_RXR		0x0a21
 #define MSG_MON_SMGR		0x0a2e
 #define MSG_MON_TXBUF		0x0a08
+
+// list of NMEA message Cls/ID
+#define MSG_NMEA_DTM 0xf00a
+#define MSG_NMEA_GBQ 0xf044
+#define MSG_NMEA_GBS 0xf009
+#define MSG_NMEA_GGA 0xf000
+#define MSG_NMEA_GLL 0xf001
+#define MSG_NMEA_GLQ 0xf043
+#define MSG_NMEA_GNQ 0xf042
+#define MSG_NMEA_GNS 0xf00d
+#define MSG_NMEA_GPQ 0xf040
+#define MSG_NMEA_GRS 0xf006
+#define MSG_NMEA_GSA 0xf002
+#define MSG_NMEA_GST 0xf007
+#define MSG_NMEA_GSV 0xf003
+#define MSG_NMEA_RMC 0xf004
+#define MSG_NMEA_TXT 0xf041
+#define MSG_NMEA_VLW 0xf00f
+#define MSG_NMEA_VTG 0xf005
+#define MSG_NMEA_ZDA 0xf008
+#define MSG_NMEA_CONFIG 0xf141
+#define MSG_NMEA_POSITION 0xf100
+#define MSG_NMEA_RATE 0xf140
+#define MSG_NMEA_SVSTATUS 0xf103
+#define MSG_NMEA_TIME 0xf104
+
 
 #include <string>
 #include <chrono>

--- a/myon_detector/structs_and_defines.h
+++ b/myon_detector/structs_and_defines.h
@@ -129,7 +129,5 @@ public:
 private:
     T value;
 };
-//Q_DECLARE_METATYPE_TEMPLATE_1ARG(gpsProperty)
-//Q_DECLARE_METATYPE(gpsProperty)
 
 #endif // STRUCTS_AND_DEFINES_H

--- a/myon_detector/tcpconnection.cpp
+++ b/myon_detector/tcpconnection.cpp
@@ -1,9 +1,5 @@
 #include "tcpconnection.h"
-#include "custom_io_operators.h" //remove after debug
 #include <QtNetwork>
-#include <sstream>
-
-using namespace std; //remove after debug
 
 const quint16 ping = 123;
 const quint16 msgSig = 246;
@@ -25,11 +21,11 @@ TcpConnection::TcpConnection(QString newHostName, quint16 newPort, int newVerbos
 }
 
 void TcpConnection::makeConnection()
+// this function gets called with a signal from client-thread
+// (TcpConnection runs in a separate thread only communicating with main thread through messages)
 {
     if (verbose > 2){
-        std::stringstream str;
-        str << "client tcpConnection reporting from thread " << this->thread();
-        emit toConsole(QString::fromStdString(str.str()));
+        emit toConsole(QString("client tcpConnection running in thread " + QString( "0x%1" ).arg( (int)this->thread(), 16 )));
     }
     tcpSocket = new QTcpSocket();
     in = new QDataStream();
@@ -53,6 +49,7 @@ void TcpConnection::closeConnection(){
 }
 
 void TcpConnection::onReadyRead(){
+    // this function gets called when tcpSocket emits readyRead signal
     if(!in){ return; }
     quint16 someCode;
     QString someMsg;
@@ -183,7 +180,7 @@ bool TcpConnection::sendFile(QString fileName){
         return true;
     }
     if(myFile->atEnd()){
-        cout << "file at end"<<endl;
+        emit toConsole("file at end");
         return true;
     }
     QByteArray block;

--- a/myon_detector/tcpconnection.cpp
+++ b/myon_detector/tcpconnection.cpp
@@ -25,7 +25,7 @@ void TcpConnection::makeConnection()
 // (TcpConnection runs in a separate thread only communicating with main thread through messages)
 {
     if (verbose > 2){
-        emit toConsole(QString("client tcpConnection running in thread " + QString( "0x%1" ).arg( (int)this->thread(), 16 )));
+        //emit toConsole(QString("client tcpConnection running in thread " + QString("0x%1").arg(this->thread())));
     }
     tcpSocket = new QTcpSocket();
     in = new QDataStream();

--- a/myon_detector/tcpconnection.cpp
+++ b/myon_detector/tcpconnection.cpp
@@ -24,8 +24,8 @@ void TcpConnection::makeConnection()
 // this function gets called with a signal from client-thread
 // (TcpConnection runs in a separate thread only communicating with main thread through messages)
 {
-    if (verbose > 2){
-        //emit toConsole(QString("client tcpConnection running in thread " + QString("0x%1").arg(this->thread())));
+    if (verbose > 4){
+        emit toConsole(QString("client tcpConnection running in thread " + QString("0x%1").arg((int)this->thread())));
     }
     tcpSocket = new QTcpSocket();
     in = new QDataStream();

--- a/myon_detector/tcpconnection.h
+++ b/myon_detector/tcpconnection.h
@@ -38,12 +38,12 @@ private:
     int verbose;
     int pingInterval;
     quint16 fileCounter = 0;
-    QFile *myFile = NULL;
-    QDataStream *in;
-    QTcpSocket *tcpSocket;
+    QFile *myFile = nullptr;
+    QDataStream *in = nullptr;
+    QTcpSocket *tcpSocket = nullptr;
 	QString hostName;
 	quint16 port;
-    QTimer *t;
+    QTimer *t = nullptr;
     time_t lastConnection;
     time_t firstConnection;
 };

--- a/myon_detector/ublox.cpp
+++ b/myon_detector/ublox.cpp
@@ -99,8 +99,7 @@ void Ublox::loop()//run()
     while (!q) {
 		std::string answer = "";
         std::string buf = "";
-        int n = 0;
-        n = ReadBuffer(buf);
+        ReadBuffer(buf);
         mutex.lock();
         q = quit;
         mutex.unlock();
@@ -111,7 +110,7 @@ void Ublox::loop()//run()
             //std::this_thread::yield();
             //std::this_thread::sleep_for(std::chrono::milliseconds(100));
             delay(100);
-            n = ReadBuffer(buf);
+            ReadBuffer(buf);
             if (dumpraw){
                 //cout << buf;
                 emit toConsole(QString::fromStdString(buf));
@@ -131,8 +130,6 @@ void Ublox::loop()//run()
 				// 	cout<<"received UBX message "<<hex<<(int)message.classID<<" "<<hex<<(int)message.messageID<<" : ";
                 tempStream << "received UBX message " << "0x" << hex << setw(4) << setfill('0') << message.msgID << " : ";
                 for (std::string::size_type i = 0; i < answer.size(); i++) tempStream << hex << setw(2) << setfill('0') << (int)answer[i] << " ";
-                string temp;
-                //tempStream >> temp;
                 emit toConsole(QString::fromStdString(tempStream.str()));
 			}
             answer = scanUnknownMessage(buffer, message.msgID);


### PR DESCRIPTION
There are still minor things left undone like ackack and some outgoing message buffer and of course a function to poll all configuration (and some way to send the information to the not yet programmed GUI).
This version works fine with the ublox m8 gps module. It can change active outgoing protocol of the gps module and deactivates all NMEA messages and activates a bunch of ubx messages. This is not yet changeable on the run. The idea is to be able to communicate with the program through a local or remote tcp connection separated to the already possible client-server connection.